### PR TITLE
Update unified-planning dependency

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -16,6 +16,5 @@ vcs pull
 mobipick/install-deps.sh
 
 # Install Unified Planning library and its planners.
-pip3 install 'unified-planning[tamer,fast-downward]==0.5.0.34.dev1'
-pip3 install 'pyparsing>=3'   # has to be installed manually, see https://github.com/aiplan4eu/unified-planning/issues/325
+pip3 install 'unified-planning[tamer,fast-downward]==0.5.0.304.dev1'
 pip3 install unified-planning-bridge/

--- a/tables_demo_planning/nodes/pick_n_place_demo_node.py
+++ b/tables_demo_planning/nodes/pick_n_place_demo_node.py
@@ -119,7 +119,7 @@ def run_demo():
 
 
 if __name__ == '__main__':
-    unified_planning.shortcuts.get_env().credits_stream = None
+    unified_planning.shortcuts.get_environment().credits_stream = None
     try:
         run_demo()
     except rospy.ROSInterruptException:

--- a/tables_demo_planning/nodes/tables_demo_node.py
+++ b/tables_demo_planning/nodes/tables_demo_node.py
@@ -295,7 +295,7 @@ class TablesDemoAPIDomain(TablesDemoDomain[TablesDemoAPIEnv]):
 
 
 if __name__ == '__main__':
-    unified_planning.shortcuts.get_env().credits_stream = None
+    unified_planning.shortcuts.get_environment().credits_stream = None
     try:
         target_location = Location.table_2
         if len(sys.argv) >= 2:

--- a/tables_demo_planning/nodes/uplexmo_pick_n_place_demo_node.py
+++ b/tables_demo_planning/nodes/uplexmo_pick_n_place_demo_node.py
@@ -113,7 +113,7 @@ class PickAndPlaceOrchestrator:
 
 
 if __name__ == "__main__":
-    unified_planning.shortcuts.get_env().credits_stream = None
+    unified_planning.shortcuts.get_environment().credits_stream = None
     try:
         PickAndPlaceOrchestrator().generate_and_execute_plan()
     except rospy.ROSInterruptException:

--- a/tables_demo_planning/test/test_tables_demo.py
+++ b/tables_demo_planning/test/test_tables_demo.py
@@ -115,7 +115,7 @@ class TablesDemoSimDomain(TablesDemoDomain[TablesDemoSimEnv]):
 
 
 def test_tables_demo() -> None:
-    unified_planning.shortcuts.get_env().credits_stream = None
+    unified_planning.shortcuts.get_environment().credits_stream = None
     # Define environment values.
     item_locations = {
         Item.multimeter: Location.table_3,


### PR DESCRIPTION
The new version correctly depends on pyparsing>=3, so we don't have to install it manually any more.