### PR TITLE
Add aliases for duplicate poses

### DIFF
--- a/tables_demo_planning/src/tables_demo_planning/demo_domain.py
+++ b/tables_demo_planning/src/tables_demo_planning/demo_domain.py
@@ -59,8 +59,6 @@ E = TypeVar('E', bound=EnvironmentRepresentation)
 class Domain(Bridge, Generic[E]):
     BASE_HANDOVER_POSE_NAME = "base_handover_pose"
     BASE_HOME_POSE_NAME = "base_home_pose"
-    BASE_PICK_POSE_NAME = "base_pick_pose"
-    BASE_PLACE_POSE_NAME = "base_place_pose"
     BASE_TABLE_1_POSE_NAME = "base_table_1_pose"
     BASE_TABLE_2_POSE_NAME = "base_table_2_pose"
     BASE_TABLE_3_POSE_NAME = "base_table_3_pose"
@@ -82,20 +80,12 @@ class Domain(Bridge, Generic[E]):
         # Create objects for both planning and execution.
         self.robot = self.create_object("mobipick", env.robot)
         rosparam_namespace = "/mobipick/tables_demo_planning"
-        self.pose_aliases = {
-            self.BASE_HANDOVER_POSE_NAME: self.BASE_HANDOVER_POSE_NAME,
-            self.BASE_HOME_POSE_NAME: self.BASE_HOME_POSE_NAME,
-            self.BASE_PICK_POSE_NAME: self.BASE_PICK_POSE_NAME,
-            self.BASE_PLACE_POSE_NAME: self.BASE_PLACE_POSE_NAME,
-        }
         self.api_poses: Dict[str, Pose] = {}
         for param_path in rosparam.list_params(rosparam_namespace):
             assert isinstance(param_path, str)
             param = rosparam.get_param(param_path)
             param_name = param_path.rsplit('/', maxsplit=1)[-1]
-            if param_name.endswith("_pose_name") and isinstance(param, str):
-                self.pose_aliases[param_name[:-5]] = param
-            elif is_instance(param, Sequence[Sequence[Union[float, int]]]) and tuple(map(len, param)) == (3, 4):
+            if is_instance(param, Sequence[Sequence[Union[float, int]]]) and tuple(map(len, param)) == (3, 4):
                 self.api_poses[param_name] = TuplePose.to_pose(param)
         if len({TuplePose.from_pose(pose) for pose in self.api_poses.values()}) < len(self.api_poses):
             rospy.logwarn(
@@ -103,10 +93,8 @@ class Domain(Bridge, Generic[E]):
                 " might let checks fail whether something is at a specific symbolic pose."
             )
         self.poses = self.create_objects(self.api_poses)
-        self.base_home_pose = self.objects[self.pose_aliases[self.BASE_HOME_POSE_NAME]]
-        self.base_handover_pose = self.objects[self.pose_aliases[self.BASE_HANDOVER_POSE_NAME]]
-        self.base_pick_pose = self.objects[self.pose_aliases[self.BASE_PICK_POSE_NAME]]
-        self.base_place_pose = self.objects[self.pose_aliases[self.BASE_PLACE_POSE_NAME]]
+        self.base_home_pose = self.objects[self.BASE_HOME_POSE_NAME]
+        self.base_handover_pose = self.objects[self.BASE_HANDOVER_POSE_NAME]
         self.base_table_1_pose = self.objects[self.BASE_TABLE_1_POSE_NAME]
         self.base_table_2_pose = self.objects[self.BASE_TABLE_2_POSE_NAME]
         self.base_table_3_pose = self.objects[self.BASE_TABLE_3_POSE_NAME]
@@ -168,8 +156,6 @@ class Domain(Bridge, Generic[E]):
         self.parameter_labels: Dict[Object, str] = {
             self.base_home_pose: "home",
             self.base_handover_pose: "handover",
-            self.base_pick_pose: "pick",
-            self.base_place_pose: "place",
             self.base_table_1_pose: "table_1",
             self.base_table_2_pose: "table_2",
             self.base_table_3_pose: "table_3",

--- a/tables_demo_planning/src/tables_demo_planning/demo_domain.py
+++ b/tables_demo_planning/src/tables_demo_planning/demo_domain.py
@@ -82,22 +82,31 @@ class Domain(Bridge, Generic[E]):
         # Create objects for both planning and execution.
         self.robot = self.create_object("mobipick", env.robot)
         rosparam_namespace = "/mobipick/tables_demo_planning"
+        self.pose_aliases = {
+            self.BASE_HANDOVER_POSE_NAME: self.BASE_HANDOVER_POSE_NAME,
+            self.BASE_HOME_POSE_NAME: self.BASE_HOME_POSE_NAME,
+            self.BASE_PICK_POSE_NAME: self.BASE_PICK_POSE_NAME,
+            self.BASE_PLACE_POSE_NAME: self.BASE_PLACE_POSE_NAME,
+        }
         self.api_poses: Dict[str, Pose] = {}
-        for param_name in rosparam.list_params(rosparam_namespace):
-            assert isinstance(param_name, str)
-            param = rosparam.get_param(param_name)
-            if is_instance(param, Sequence[Sequence[Union[float, int]]]) and tuple(map(len, param)) == (3, 4):
-                self.api_poses[param_name.rsplit('/', maxsplit=1)[-1]] = TuplePose.to_pose(param)
+        for param_path in rosparam.list_params(rosparam_namespace):
+            assert isinstance(param_path, str)
+            param = rosparam.get_param(param_path)
+            param_name = param_path.rsplit('/', maxsplit=1)[-1]
+            if param_name.endswith("_pose_name") and isinstance(param, str):
+                self.pose_aliases[param_name[:-5]] = param
+            elif is_instance(param, Sequence[Sequence[Union[float, int]]]) and tuple(map(len, param)) == (3, 4):
+                self.api_poses[param_name] = TuplePose.to_pose(param)
         if len({TuplePose.from_pose(pose) for pose in self.api_poses.values()}) < len(self.api_poses):
             rospy.logwarn(
                 f"Duplicate poses in rosparam namespace '{rosparam_namespace}'"
                 " might let checks fail whether something is at a specific symbolic pose."
             )
         self.poses = self.create_objects(self.api_poses)
-        self.base_home_pose = self.objects[self.BASE_HOME_POSE_NAME]
-        self.base_handover_pose = self.objects[self.BASE_HANDOVER_POSE_NAME]
-        self.base_pick_pose = self.objects[self.BASE_PICK_POSE_NAME]
-        self.base_place_pose = self.objects[self.BASE_PLACE_POSE_NAME]
+        self.base_home_pose = self.objects[self.pose_aliases[self.BASE_HOME_POSE_NAME]]
+        self.base_handover_pose = self.objects[self.pose_aliases[self.BASE_HANDOVER_POSE_NAME]]
+        self.base_pick_pose = self.objects[self.pose_aliases[self.BASE_PICK_POSE_NAME]]
+        self.base_place_pose = self.objects[self.pose_aliases[self.BASE_PLACE_POSE_NAME]]
         self.base_table_1_pose = self.objects[self.BASE_TABLE_1_POSE_NAME]
         self.base_table_2_pose = self.objects[self.BASE_TABLE_2_POSE_NAME]
         self.base_table_3_pose = self.objects[self.BASE_TABLE_3_POSE_NAME]

--- a/tables_demo_planning/src/tables_demo_planning/pick_n_place_demo.py
+++ b/tables_demo_planning/src/tables_demo_planning/pick_n_place_demo.py
@@ -94,17 +94,16 @@ class PickAndPlaceEnv(EnvironmentRepresentation[PickAndPlaceRobot]):
 
 
 class PickAndPlaceDomain(Domain[PickAndPlaceEnv]):
-    SCENARIO_POSE_NAMES = (
-        Domain.BASE_HANDOVER_POSE_NAME,
-        Domain.BASE_HOME_POSE_NAME,
-        Domain.BASE_PICK_POSE_NAME,
-        Domain.BASE_PLACE_POSE_NAME,
-    )
-
     def __init__(self) -> None:
         super().__init__(PickAndPlaceEnv())
+        self.scenario_pose_names = (
+            self.pose_aliases[Domain.BASE_HANDOVER_POSE_NAME],
+            self.pose_aliases[Domain.BASE_HOME_POSE_NAME],
+            self.pose_aliases[Domain.BASE_PICK_POSE_NAME],
+            self.pose_aliases[Domain.BASE_PLACE_POSE_NAME],
+        )
         self.env.robot.add_waypoints(
-            {pose_name: pose for pose_name, pose in self.api_poses.items() if pose_name in self.SCENARIO_POSE_NAMES}
+            {pose_name: pose for pose_name, pose in self.api_poses.items() if pose_name in self.scenario_pose_names}
         )
         self.env.robot.initialize(self.api_poses[self.BASE_HOME_POSE_NAME], *self.env.robot.get())
         self.set_fluent_functions([self.get_robot_at])
@@ -155,7 +154,7 @@ class PickAndPlaceDomain(Domain[PickAndPlaceEnv]):
             actions.append(self.hand_over)
         return self.define_mobipick_problem(
             actions=actions,
-            poses=[self.objects[pose_name] for pose_name in self.SCENARIO_POSE_NAMES],
+            poses=[self.objects[pose_name] for pose_name in self.scenario_pose_names],
             items=[self.power_drill],
             locations=[],
         )

--- a/tables_demo_planning/src/tables_demo_planning/pick_n_place_demo.py
+++ b/tables_demo_planning/src/tables_demo_planning/pick_n_place_demo.py
@@ -36,6 +36,7 @@
 """Pick and Place application in the Mobipick domain"""
 
 
+import rosparam
 from unified_planning.model import Object, Problem
 from unified_planning.shortcuts import Not
 from tables_demo_planning.mobipick_components import APIRobot, ArmPose, EnvironmentRepresentation, Item
@@ -96,12 +97,31 @@ class PickAndPlaceEnv(EnvironmentRepresentation[PickAndPlaceRobot]):
 class PickAndPlaceDomain(Domain[PickAndPlaceEnv]):
     def __init__(self) -> None:
         super().__init__(PickAndPlaceEnv())
-        self.scenario_pose_names = (
-            self.pose_aliases[Domain.BASE_HANDOVER_POSE_NAME],
-            self.pose_aliases[Domain.BASE_HOME_POSE_NAME],
-            self.pose_aliases[Domain.BASE_PICK_POSE_NAME],
-            self.pose_aliases[Domain.BASE_PLACE_POSE_NAME],
+        # Read pose parameters from rosparam server.
+        rosparam_namespace = "/mobipick/tables_demo_planning"
+        params = rosparam.list_params(rosparam_namespace)
+        self.base_handover_pose_name = (
+            rosparam.get_param(rosparam_namespace + "/base_handover_pose_name")
+            if rosparam_namespace + "/base_handover_pose_name" in params
+            else self.BASE_HANDOVER_POSE_NAME
         )
+        self.base_home_pose_name = (
+            rosparam.get_param(rosparam_namespace + "/base_home_pose_name")
+            if rosparam_namespace + "/base_home_pose_name" in params
+            else self.BASE_HOME_POSE_NAME
+        )
+        self.base_pick_pose_name = rosparam.get_param(rosparam_namespace + "/base_pick_pose_name")
+        self.base_place_pose_name = rosparam.get_param(rosparam_namespace + "/base_place_pose_name")
+
+        # Define scenario poses and waypoints.
+        self.scenario_pose_names = (
+            self.base_handover_pose_name,
+            self.base_home_pose_name,
+            self.base_pick_pose_name,
+            self.base_place_pose_name,
+        )
+        self.base_pick_pose = self.objects[self.base_pick_pose_name]
+        self.base_place_pose = self.objects[self.base_place_pose_name]
         self.env.robot.add_waypoints(
             {pose_name: pose for pose_name, pose in self.api_poses.items() if pose_name in self.scenario_pose_names}
         )
@@ -109,6 +129,7 @@ class PickAndPlaceDomain(Domain[PickAndPlaceEnv]):
         self.set_fluent_functions([self.get_robot_at])
         self.item_offered = self.create_fluent_from_function(self.env.get_item_offered)
 
+        # Create additional actions.
         self.set_api_actions(
             (PickAndPlaceRobot.move_base, PickAndPlaceRobot.move_base_with_item, PickAndPlaceRobot.move_arm)
         )
@@ -134,11 +155,19 @@ class PickAndPlaceDomain(Domain[PickAndPlaceEnv]):
         for item in self.items:
             self.hand_over.add_effect(self.robot_has(item), item == self.nothing)
         self.hand_over.add_effect(self.item_offered, True)
+
+        # Create additional visualization labels.
         self.method_labels.update(
             {
                 self.pick: lambda _: "Pick up power drill",
                 self.place: lambda _: "Place power drill on table",
                 self.hand_over: lambda _: "Hand over power drill to person",
+            }
+        )
+        self.parameter_labels.update(
+            {
+                self.base_pick_pose: "pick",
+                self.base_place_pose: "place",
             }
         )
 


### PR DESCRIPTION
Duplicate poses, i.e. different symbols representing the same pose, in the pick_n_place demo are handled by
- still not supporting them directly, thus the warning remains,
- introducing pose aliases in the config file and on the rosparam server,
- reading the pose aliases in the pick_n_place demo to get the actual pose name.

Note that this replaces "pick_pose" and "place_pose" in the output by their concrete table pose symbol.

Requires: https://git.ni.dfki.de/mobipick/mobipick/-/merge_requests/21