### PR TITLE
add handover action to tables demo domain

### DIFF
--- a/tables_demo_planning/nodes/tables_demo_node.py
+++ b/tables_demo_planning/nodes/tables_demo_node.py
@@ -59,6 +59,6 @@ if __name__ == '__main__':
                 target_location = Location.table_3
             else:
                 rospy.logwarn(f"Unknown parameter '{parameter}', using default table.")
-        TablesDemoAPIDomain(target_location).run()
+        TablesDemoAPIDomain().run(target_location)
     except rospy.ROSInterruptException:
         pass

--- a/tables_demo_planning/nodes/uplexmo_tables_demo_node.py
+++ b/tables_demo_planning/nodes/uplexmo_tables_demo_node.py
@@ -56,8 +56,8 @@ from unified_planning.model import UPState
 
 
 class TablesDemoOrchestrator:
-    def __init__(self, target_location: Location) -> None:
-        self._domain = TablesDemoAPIDomain(target_location)
+    def __init__(self) -> None:
+        self._domain = TablesDemoAPIDomain()
         self.visualization: Optional[SubPlanVisualization] = None
         self.espeak_pub: Optional[rospy.Publisher] = None
         self._trigger_replanning = False  # Temporary solution until it is provided by dispatcher
@@ -182,8 +182,8 @@ class TablesDemoOrchestrator:
             self._domain.env.item_search = None
         return result
 
-    def generate_and_execute_plan(self) -> None:
-        print(f"Scenario: Mobipick shall bring the box with the multimeter inside to {self._domain.target_table}.")
+    def generate_and_execute_plan(self, target_location: Location) -> None:
+        print(f"Scenario: Mobipick shall bring the box with the multimeter inside to {self._domain.objects[target_location.name]}.")
         self._executed_actions: Set[str] = set()
         # retries_before_abortion = self._domain.RETRIES_BEFORE_ABORTION  # FIXME Currently not used
         # error_counts: Dict[str, int] = defaultdict(int) # FIXME Currently not used
@@ -193,7 +193,7 @@ class TablesDemoOrchestrator:
             self._trigger_replanning = False
             # Plan
             self._domain.set_initial_values(self._domain.problem)
-            self._domain.set_goals()
+            self._domain.set_goals(target_location)
             plan = self.solve_problem(self._domain.problem)
             if not plan:
                 print("Could not find a plan. Exiting.")
@@ -225,6 +225,6 @@ if __name__ == '__main__':
                 target_location = Location.table_3
             else:
                 rospy.logwarn(f"Unknown parameter '{parameter}', using default table.")
-        TablesDemoOrchestrator(target_location).generate_and_execute_plan()
+        TablesDemoOrchestrator().generate_and_execute_plan(target_location)
     except rospy.ROSInterruptException:
         pass

--- a/tables_demo_planning/src/tables_demo_planning/tables_demo.py
+++ b/tables_demo_planning/src/tables_demo_planning/tables_demo.py
@@ -86,8 +86,8 @@ class TablesDemoRobot(Robot, ABC, Generic[E]):
         self.arm_pose = ArmPose.home
         return True
 
-    def handover_item(self, pose: Pose, item: Item) -> bool:
-        """At pose, handover holding item to a person."""
+    def hand_over_item(self, pose: Pose, item: Item) -> bool:
+        """At pose, hand over item held to a person."""
         print(f"Successfully handed {item.name} over.")
         self.item = Item.nothing
         self.env.believed_item_locations[item] = Location.anywhere
@@ -246,7 +246,7 @@ class TablesDemoDomain(Domain[E]):
         self.store_item.add_effect(self.believe_item_at(item, self.on_robot), False)
         self.store_item.add_effect(self.believe_item_at(item, self.in_box), True)
         self.handover_item, (_, pose, item) = self.create_action_from_function(
-            TablesDemoRobot.handover_item, set_callable=False
+            TablesDemoRobot.hand_over_item, set_callable=False
         )
         self.handover_item.add_precondition(self.robot_at(pose))
         self.handover_item.add_precondition(self.robot_has(item))

--- a/tables_demo_planning/src/tables_demo_planning/tables_demo.py
+++ b/tables_demo_planning/src/tables_demo_planning/tables_demo.py
@@ -304,7 +304,14 @@ class TablesDemoDomain(Domain[E]):
         self.conclude_box_search.add_effect(self.believe_item_at(self.box, self.box_search_location), True)
 
         self.problem = self.define_problem(
-            fluents=(self.robot_at, self.robot_arm_at, self.robot_has, self.believe_item_at, self.pose_at, self.offered_item),
+            fluents=(
+                self.robot_at,
+                self.robot_arm_at,
+                self.robot_has,
+                self.believe_item_at,
+                self.pose_at,
+                self.offered_item,
+            ),
             actions=(
                 self.move_base,
                 self.move_base_with_item,
@@ -396,7 +403,9 @@ class TablesDemoDomain(Domain[E]):
     def run(self, target_location: Location) -> None:
         """Run the mobipick tables demo."""
         print(
-            f"Scenario: Mobipick shall bring the box with the multimeter inside to {self.objects[target_location.name]}.")
+            "Scenario: Mobipick shall bring the box with the multimeter inside to"
+            f" {self.objects[target_location.name]}."
+        )
 
         executed_action_names: Set[str] = set()  # Note: For visualization purposes only.
         retries_before_abortion = self.RETRIES_BEFORE_ABORTION

--- a/tables_demo_planning/src/tables_demo_planning/tables_demo.py
+++ b/tables_demo_planning/src/tables_demo_planning/tables_demo.py
@@ -66,7 +66,6 @@ class TablesDemoRobot(Robot, ABC, Generic[E]):
         print(f"Successfully picked up {item.name}.")
         self.item = item
         self.env.believed_item_locations[item] = Location.on_robot
-        self.env.offered_items.discard(item)
         self.arm_pose = ArmPose.transport
         return True
 

--- a/tables_demo_planning/src/tables_demo_planning/tables_demo.py
+++ b/tables_demo_planning/src/tables_demo_planning/tables_demo.py
@@ -151,7 +151,7 @@ class TablesDemoEnv(EnvironmentRepresentation[R]):
         self.search_location = Location.anywhere
         self.offered_items: Set[Item] = set()
 
-    def get_offered_items(self, item: Item) -> bool:
+    def get_item_offered(self, item: Item) -> bool:
         return item in self.offered_items
 
     def get_believe_item_at(self, item: Item, location: Location) -> bool:
@@ -195,7 +195,7 @@ class TablesDemoDomain(Domain[E]):
         self.believe_item_at = self.create_fluent_from_function(self.env.get_believe_item_at)
         self.searched_at = self.create_fluent_from_function(self.env.get_searched_at)
         self.pose_at = self.create_fluent("get_pose_at", pose=Pose, location=Location)
-        self.offered_item = self.create_fluent_from_function(self.env.get_offered_items)
+        self.item_offered = self.create_fluent_from_function(self.env.get_item_offered)
         self.set_fluent_functions((self.get_pose_at,))
 
         self.pick_item, (_, pose, location, item) = self.create_action_from_function(
@@ -251,14 +251,14 @@ class TablesDemoDomain(Domain[E]):
         self.handover_item.add_precondition(self.robot_at(pose))
         self.handover_item.add_precondition(self.robot_has(item))
         self.handover_item.add_precondition(self.believe_item_at(item, self.on_robot))
-        self.handover_item.add_precondition(Not(self.offered_item(item)))
+        self.handover_item.add_precondition(Not(self.item_offered(item)))
         self.handover_item.add_effect(self.robot_has(item), False)
         self.handover_item.add_effect(self.robot_has(self.nothing), True)
         for arm_pose in self.arm_poses:
             self.handover_item.add_effect(self.robot_arm_at(arm_pose), arm_pose == self.arm_pose_handover)
         self.handover_item.add_effect(self.believe_item_at(item, self.on_robot), False)
         self.handover_item.add_effect(self.believe_item_at(item, self.anywhere), True)
-        self.handover_item.add_effect(self.offered_item(item), True)
+        self.handover_item.add_effect(self.item_offered(item), True)
         self.search_at, (_, pose, location) = self.create_action_from_function(TablesDemoRobot.search_at)
         self.search_at.add_precondition(self.robot_at(pose))
         self.search_at.add_precondition(
@@ -310,7 +310,7 @@ class TablesDemoDomain(Domain[E]):
                 self.robot_has,
                 self.believe_item_at,
                 self.pose_at,
-                self.offered_item,
+                self.item_offered,
             ),
             actions=(
                 self.move_base,

--- a/tables_demo_planning/src/tables_demo_planning/tables_demo.py
+++ b/tables_demo_planning/src/tables_demo_planning/tables_demo.py
@@ -85,7 +85,7 @@ class TablesDemoRobot(Robot, ABC, Generic[E]):
         self.env.believed_item_locations[item] = Location.in_box
         self.arm_pose = ArmPose.home
         return True
-    
+
     def handover_item(self, pose: Pose, item: Item) -> bool:
         """At pose, handover holding item to a person."""
         print(f"Successfully handed {item.name} over.")
@@ -358,7 +358,7 @@ class TablesDemoDomain(Domain[E]):
     def get_pose_at(self, pose: Object, location: Object) -> bool:
         return location == (self.pose_locations[pose] if pose in self.pose_locations.keys() else self.anywhere)
 
-    def set_goals(self, target_location) -> None:
+    def set_goals(self, target_location: Location) -> None:
         """Set the goals for the overall demo."""
         self.problem.clear_goals()
         if Item.box in self.DEMO_ITEMS:

--- a/tables_demo_planning/src/tables_demo_planning/tables_demo_api.py
+++ b/tables_demo_planning/src/tables_demo_planning/tables_demo_api.py
@@ -189,9 +189,9 @@ class TablesDemoAPIRobot(TablesDemoRobot['TablesDemoAPIEnv'], APIRobot):
         self.arm.move("home")
         return True
 
-    def handover_item(self, pose: Pose, item: Item) -> bool:
+    def hand_over_item(self, pose: Pose, item: Item) -> bool:
         """
-        At pose, handover item to person, observe force torque feedback
+        At pose, hand over item to person, observe force torque feedback
         until item is taken by person, then move arm to home pose.
         """
         self.arm.move("handover")
@@ -201,7 +201,7 @@ class TablesDemoAPIRobot(TablesDemoRobot['TablesDemoAPIEnv'], APIRobot):
             return False
 
         self.arm.execute("ReleaseGripper")
-        TablesDemoRobot.handover_item(self, pose, item)
+        TablesDemoRobot.hand_over_item(self, pose, item)
         return True
 
     def perceive(self, location: Location) -> Dict[Item, Location]:
@@ -283,7 +283,7 @@ class TablesDemoAPIDomain(TablesDemoDomain[TablesDemoAPIEnv]):
                 TablesDemoAPIRobot.move_arm,
                 TablesDemoAPIRobot.pick_item,
                 TablesDemoAPIRobot.place_item,
-                TablesDemoAPIRobot.handover_item,
+                TablesDemoAPIRobot.hand_over_item,
                 TablesDemoAPIRobot.store_item,
             )
         )

--- a/tables_demo_planning/src/tables_demo_planning/tables_demo_api.py
+++ b/tables_demo_planning/src/tables_demo_planning/tables_demo_api.py
@@ -189,6 +189,21 @@ class TablesDemoAPIRobot(TablesDemoRobot['TablesDemoAPIEnv'], APIRobot):
         self.arm.move("home")
         return True
 
+    def handover_item(self, pose: Pose, item: Item) -> bool:
+        """
+        At pose, handover item to person, observe force torque feedback
+        until item is taken by person, then move arm to home pose.
+        """
+        self.arm.move("handover")
+        self.arm_pose = ArmPose.handover
+        # observe force torque sensor using treshold 5.0 and a timeout of 25.0 seconds
+        if not self.arm.observe_force_torque(5.0, 25.0):
+            return False
+
+        self.arm.execute("ReleaseGripper")
+        TablesDemoRobot.handover_item(self, pose, item)
+        return True
+
     def perceive(self, location: Location) -> Dict[Item, Location]:
         """Move arm into observation pose and return all perceived items with their locations."""
         self.arm.move("observe100cm_right")
@@ -266,6 +281,7 @@ class TablesDemoAPIDomain(TablesDemoDomain[TablesDemoAPIEnv]):
                 TablesDemoAPIRobot.move_arm,
                 TablesDemoAPIRobot.pick_item,
                 TablesDemoAPIRobot.place_item,
+                TablesDemoAPIRobot.handover_item,
                 TablesDemoAPIRobot.store_item,
             )
         )

--- a/tables_demo_planning/src/tables_demo_planning/tables_demo_api.py
+++ b/tables_demo_planning/src/tables_demo_planning/tables_demo_api.py
@@ -232,6 +232,8 @@ class TablesDemoAPIRobot(TablesDemoRobot['TablesDemoAPIEnv'], APIRobot):
                 ):
                     rospy.loginfo(f"{fact_item_name} is perceived as on {fact_location_name}.")
                     perceived_item_locations[Item(fact_item_name)] = location
+                    # Remove item from offered_items dict to be able to repeat the handover
+                    # action with that item, if it is perceived again in the scene.
                     self.env.offered_items.discard(Item(fact_item_name))
         # Also perceive facts for items in box if it is perceived on table location.
         for fact in facts:
@@ -244,6 +246,8 @@ class TablesDemoAPIRobot(TablesDemoRobot['TablesDemoAPIEnv'], APIRobot):
                 ):
                     rospy.loginfo(f"{fact_item_name} is perceived as on {fact_location_name}.")
                     perceived_item_locations[Item(fact_item_name)] = Location.in_box
+                    # Remove item from offered_items dict to be able to repeat the handover
+                    # action with that item, if it is perceived again in the scene.
                     self.env.offered_items.discard(Item(fact_item_name))
         # Determine newly perceived items and their locations.
         self.env.newly_perceived_item_locations.clear()

--- a/tables_demo_planning/src/tables_demo_planning/tables_demo_api.py
+++ b/tables_demo_planning/src/tables_demo_planning/tables_demo_api.py
@@ -232,6 +232,7 @@ class TablesDemoAPIRobot(TablesDemoRobot['TablesDemoAPIEnv'], APIRobot):
                 ):
                     rospy.loginfo(f"{fact_item_name} is perceived as on {fact_location_name}.")
                     perceived_item_locations[Item(fact_item_name)] = location
+                    self.env.offered_items.discard(Item(fact_item_name))
         # Also perceive facts for items in box if it is perceived on table location.
         for fact in facts:
             if fact.name == "in":
@@ -243,6 +244,7 @@ class TablesDemoAPIRobot(TablesDemoRobot['TablesDemoAPIEnv'], APIRobot):
                 ):
                     rospy.loginfo(f"{fact_item_name} is perceived as on {fact_location_name}.")
                     perceived_item_locations[Item(fact_item_name)] = Location.in_box
+                    self.env.offered_items.discard(Item(fact_item_name))
         # Determine newly perceived items and their locations.
         self.env.newly_perceived_item_locations.clear()
         for perceived_item, perceived_location in perceived_item_locations.items():

--- a/tables_demo_planning/src/tables_demo_planning/tables_demo_api.py
+++ b/tables_demo_planning/src/tables_demo_planning/tables_demo_api.py
@@ -254,8 +254,8 @@ class TablesDemoAPIEnv(TablesDemoEnv[TablesDemoAPIRobot]):
 
 
 class TablesDemoAPIDomain(TablesDemoDomain[TablesDemoAPIEnv]):
-    def __init__(self, target_location: Location) -> None:
-        super().__init__(TablesDemoAPIEnv(), target_location)
+    def __init__(self) -> None:
+        super().__init__(TablesDemoAPIEnv())
         self.env.robot.add_waypoints(self.api_poses)
         self.env.robot.initialize(self.api_poses[self.BASE_HOME_POSE_NAME], *self.env.robot.get())
         self.set_fluent_functions((self.get_robot_at,))

--- a/tables_demo_planning/test/test_tables_demo.py
+++ b/tables_demo_planning/test/test_tables_demo.py
@@ -96,8 +96,8 @@ class TablesDemoSimEnv(TablesDemoEnv[TablesDemoSimRobot]):
 
 
 class TablesDemoSimDomain(TablesDemoDomain[TablesDemoSimEnv]):
-    def __init__(self, item_locations: Dict[Item, Location], target_location: Location) -> None:
-        super().__init__(TablesDemoSimEnv(item_locations), target_location)
+    def __init__(self, item_locations: Dict[Item, Location]) -> None:
+        super().__init__(TablesDemoSimEnv(item_locations))
         home_pose = self.api_poses[self.BASE_HOME_POSE_NAME]
         self.env.robot.initialize(home_pose, home_pose, ArmPose.unknown, Item.nothing)
         self.set_fluent_functions((self.get_robot_at,))
@@ -128,7 +128,7 @@ def test_tables_demo() -> None:
     # Define goal.
     target_location = Location.table_2
 
-    TablesDemoSimDomain(item_locations, target_location).run()
+    TablesDemoSimDomain(item_locations).run(target_location)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- added handover action to domain
- added fluent for handover action to track, which items where already handed over. This fluent is removed again if an item is perceived on a table or in a box. This allows the handover action to be performed again if the item reappears in the scene.
- moved target_location parameter from class constructor to run() function