### PR TITLE
Add hierarchical domain to tables demo

### DIFF
--- a/tables_demo_planning/CMakeLists.txt
+++ b/tables_demo_planning/CMakeLists.txt
@@ -19,5 +19,6 @@ catkin_install_python(PROGRAMS
   nodes/tables_demo_node.py
   nodes/uplexmo_pick_n_place_demo_node.py
   nodes/uplexmo_tables_demo_node.py
+  nodes/hierarchical_demo_node.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/tables_demo_planning/nodes/hierarchical_demo_node.py
+++ b/tables_demo_planning/nodes/hierarchical_demo_node.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+
+# Software License Agreement (BSD License)
+#
+#  Copyright (c) 2022, DFKI GmbH
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the following
+#     disclaimer in the documentation and/or other materials provided
+#     with the distribution.
+#   * Neither the name of Willow Garage nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+#  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+#  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+#  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+#  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+#  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+#  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+#  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+#  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# Authors: Sebastian Stock, Alexander Sung, Marc Vinci
+
+"""
+Main execution node of the tables demo using hierarchical planning for execution.
+Development in progress.
+"""
+
+
+import sys
+import rospy
+import unified_planning
+from typing import Optional
+from tables_demo_planning.mobipick_components import Item, Location
+from tables_demo_planning.hierarchical_domain import HierarchicalDomain
+from tables_demo_planning.subplan_visualization import SubPlanVisualization
+
+
+class HierarchicalDemoOrchestrator:
+    def __init__(self) -> None:
+        self._domain = HierarchicalDomain()
+        self.visualization: Optional[SubPlanVisualization] = None
+        self.espeak_pub: Optional[rospy.Publisher] = None
+        self._trigger_replanning = False  # Temporary solution until it is provided by dispatcher
+
+    def generate_and_execute_plan(self, target_item: Item, target_box: Item, target_location: Location) -> None:
+        print(
+            f"Scenario: Mobipick shall bring the {self._domain.objects[target_box.name]}"
+            f" with the {self._domain.objects[target_item.name]} inside"
+            f" to {self._domain.objects[target_location.name]}."
+        )
+
+        self._domain.run(
+            self._domain.objects[target_item.name],
+            self._domain.objects[target_box.name],
+            self._domain.objects[target_location.name],
+        )
+
+
+if __name__ == '__main__':
+    unified_planning.shortcuts.get_environment().credits_stream = None
+    try:
+        target_location = Location.table_2
+        if len(sys.argv) >= 2:
+            parameter = sys.argv[1]
+            if parameter in ("1", "table1", "table_1"):
+                target_location = Location.table_1
+            elif parameter in ("2", "table2", "table_2"):
+                target_location = Location.table_2
+            elif parameter in ("3", "table3", "table_3"):
+                target_location = Location.table_3
+            else:
+                rospy.logwarn(f"Unknown parameter '{parameter}', using default table.")
+
+        target_item = Item.multimeter
+        target_box = Item.box
+        HierarchicalDemoOrchestrator().generate_and_execute_plan(target_item, target_box, target_location)
+    except rospy.ROSInterruptException:
+        pass

--- a/tables_demo_planning/nodes/uplexmo_tables_demo_node.py
+++ b/tables_demo_planning/nodes/uplexmo_tables_demo_node.py
@@ -184,8 +184,8 @@ class TablesDemoOrchestrator:
 
     def generate_and_execute_plan(self, target_location: Location) -> None:
         print(
-            "Scenario: Mobipick shall bring the box with the multimeter inside to"
-            f"{self._domain.objects[target_location.name]}."
+            "Scenario: Mobipick shall bring the box with the multimeter"
+            f" inside to {self._domain.objects[target_location.name]}."
         )
         self._executed_actions: Set[str] = set()
         # retries_before_abortion = self._domain.RETRIES_BEFORE_ABORTION  # FIXME Currently not used

--- a/tables_demo_planning/src/tables_demo_planning/hierarchical_domain.py
+++ b/tables_demo_planning/src/tables_demo_planning/hierarchical_domain.py
@@ -254,14 +254,15 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         )
         self.insert_item_store.add_precondition(self.robot_has(self.insert_item_store.item))
         self.insert_item_store.add_precondition(self.robot_at(self.insert_item_store.box_pose))
-        self.insert_item_store.add_subtask(self.drive, self.insert_item_store.box_pose)
-        self.insert_item_store.add_subtask(
+        s1 = self.insert_item_store.add_subtask(self.drive, self.insert_item_store.box_pose)
+        s2 = self.insert_item_store.add_subtask(
             self.store_item,
             self.robot,
             self.insert_item_store.box_pose,
             self.insert_item_store.box_loc,
             self.insert_item_store.item,
         )
+        self.insert_item_store.set_ordered(s1, s2)
 
         # already holding item, move to box and insert
         self.insert_item_drive = Method(
@@ -277,14 +278,15 @@ class HierarchicalDomain(TablesDemoAPIDomain):
             self.pose_at(self.insert_item_drive.box_pose, self.insert_item_drive.box_loc)
         )
         self.insert_item_drive.add_precondition(self.robot_has(self.insert_item_drive.item))
-        self.insert_item_drive.add_subtask(self.drive, self.insert_item_drive.box_pose)
-        self.insert_item_drive.add_subtask(
+        s1 = self.insert_item_drive.add_subtask(self.drive, self.insert_item_drive.box_pose)
+        s2 = self.insert_item_drive.add_subtask(
             self.store_item,
             self.robot,
             self.insert_item_drive.box_pose,
             self.insert_item_drive.box_loc,
             self.insert_item_drive.item,
         )
+        self.insert_item_drive.set_ordered(s1, s2)
 
         # go to item location, pickup item, go to box location, store item in box
         self.insert_item_full = Method(
@@ -299,15 +301,16 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         self.insert_item_full.add_precondition(
             self.pose_at(self.insert_item_full.box_pose, self.insert_item_full.box_loc)
         )
-        self.insert_item_full.add_subtask(self.get_item, self.insert_item_full.item)
-        self.insert_item_full.add_subtask(self.drive, self.insert_item_full.box_pose)
-        self.insert_item_full.add_subtask(
+        s1 = self.insert_item_full.add_subtask(self.get_item, self.insert_item_full.item)
+        s2 = self.insert_item_full.add_subtask(self.drive, self.insert_item_full.box_pose)
+        s3 = self.insert_item_full.add_subtask(
             self.store_item,
             self.robot,
             self.insert_item_full.box_pose,
             self.insert_item_full.box_loc,
             self.insert_item_full.item,
         )
+        self.insert_item_full.set_ordered(s1, s2, s3)
 
         # BRING ITEM
         # robot already has item and is at handover pose, hand item over, move arm to home pose
@@ -433,12 +436,13 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         self.tables_demo_insert_tool_move.add_precondition(
             Not(self.believe_item_at(self.tables_demo_insert_tool_move.box, self.anywhere))
         )
-        self.tables_demo_insert_tool_move.add_subtask(
+        s1 = self.tables_demo_insert_tool_move.add_subtask(
             self.insert_item, self.tables_demo_insert_tool_move.tool, self.tables_demo_insert_tool_move.box
         )
-        self.tables_demo_insert_tool_move.add_subtask(
+        s2 = self.tables_demo_insert_tool_move.add_subtask(
             self.move_item, self.tables_demo_insert_tool_move.box, self.tables_demo_insert_tool_move.location
         )
+        self.tables_demo_insert_tool_move.set_ordered(s1, s2)
 
         # already holding tool
         self.tables_demo_search_box = Method(
@@ -457,13 +461,14 @@ class HierarchicalDomain(TablesDemoAPIDomain):
             self.believe_item_at(self.tables_demo_search_box.tool, self.on_robot)
         )
         self.tables_demo_search_box.add_precondition(self.robot_has(self.tables_demo_search_box.tool))
-        self.tables_demo_search_box.add_subtask(self.search_box, self.robot)
-        self.tables_demo_search_box.add_subtask(
+        s1 = self.tables_demo_search_box.add_subtask(self.search_box, self.robot)
+        s2 = self.tables_demo_search_box.add_subtask(
             self.insert_item, self.tables_demo_search_box.tool, self.tables_demo_search_box.box
         )
-        self.tables_demo_search_box.add_subtask(
+        s3 = self.tables_demo_search_box.add_subtask(
             self.move_item, self.tables_demo_search_box.box, self.tables_demo_search_box.location
         )
+        self.tables_demo_search_box.set_ordered(s1, s2, s3)
 
         # box location already known and on target table
         self.tables_demo_search_tool = Method(
@@ -481,11 +486,12 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         self.tables_demo_search_tool.add_precondition(
             self.believe_item_at(self.tables_demo_search_tool.box, self.tables_demo_search_tool.location)
         )
-        self.tables_demo_search_tool.add_subtask(self.search_tool, self.robot, self.tables_demo_search_tool.tool)
-        self.tables_demo_search_tool.add_subtask(self.get_item, self.tables_demo_search_tool.tool)
-        self.tables_demo_search_tool.add_subtask(
+        s1 = self.tables_demo_search_tool.add_subtask(self.search_tool, self.robot, self.tables_demo_search_tool.tool)
+        s2 = self.tables_demo_search_tool.add_subtask(self.get_item, self.tables_demo_search_tool.tool)
+        s3 = self.tables_demo_search_tool.add_subtask(
             self.insert_item, self.tables_demo_search_tool.tool, self.tables_demo_search_tool.box
         )
+        self.tables_demo_search_tool.set_ordered(s1, s2, s3)
 
         # box location already known
         self.tables_demo_search_tool_move = Method(
@@ -506,16 +512,17 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         self.tables_demo_search_tool_move.add_precondition(
             Not(self.believe_item_at(self.tables_demo_search_tool_move.box, self.tables_demo_search_tool_move.location))
         )
-        self.tables_demo_search_tool_move.add_subtask(
+        s1 = self.tables_demo_search_tool_move.add_subtask(
             self.search_tool, self.robot, self.tables_demo_search_tool_move.tool
         )
-        self.tables_demo_search_tool_move.add_subtask(self.get_item, self.tables_demo_search_tool_move.tool)
-        self.tables_demo_search_tool_move.add_subtask(
+        s2 = self.tables_demo_search_tool_move.add_subtask(self.get_item, self.tables_demo_search_tool_move.tool)
+        s3 = self.tables_demo_search_tool_move.add_subtask(
             self.insert_item, self.tables_demo_search_tool_move.tool, self.tables_demo_search_tool_move.box
         )
-        self.tables_demo_search_tool_move.add_subtask(
+        s4 = self.tables_demo_search_tool_move.add_subtask(
             self.move_item, self.tables_demo_search_tool_move.box, self.tables_demo_search_tool_move.location
         )
+        self.tables_demo_search_tool_move.set_ordered(s1, s2, s3, s4)
 
         # tool location already known
         self.tables_demo_get_tool = Method(
@@ -530,14 +537,15 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         self.tables_demo_get_tool.add_precondition(
             Not(self.believe_item_at(self.tables_demo_get_tool.tool, self.anywhere))
         )
-        self.tables_demo_get_tool.add_subtask(self.get_item, self.tables_demo_get_tool.tool)
-        self.tables_demo_get_tool.add_subtask(self.search_box, self.robot)
-        self.tables_demo_get_tool.add_subtask(
+        s1 = self.tables_demo_get_tool.add_subtask(self.get_item, self.tables_demo_get_tool.tool)
+        s2 = self.tables_demo_get_tool.add_subtask(self.search_box, self.robot)
+        s3 = self.tables_demo_get_tool.add_subtask(
             self.insert_item, self.tables_demo_get_tool.tool, self.tables_demo_get_tool.box
         )
-        self.tables_demo_get_tool.add_subtask(
+        s4 = self.tables_demo_get_tool.add_subtask(
             self.move_item, self.tables_demo_get_tool.box, self.tables_demo_get_tool.location
         )
+        self.tables_demo_get_tool.set_ordered(s1, s2, s3, s4)
 
         # full tables demo
         self.tables_demo_full = Method(
@@ -546,11 +554,12 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         self.tables_demo_full.set_task(
             self.tables_demo, self.tables_demo_full.tool, self.tables_demo_full.box, self.tables_demo_full.location
         )
-        self.tables_demo_full.add_subtask(self.search_tool, self.robot, self.tables_demo_full.tool)
-        self.tables_demo_full.add_subtask(self.get_item, self.tables_demo_full.tool)
-        self.tables_demo_full.add_subtask(self.search_box, self.robot)
-        self.tables_demo_full.add_subtask(self.insert_item, self.tables_demo_full.tool, self.tables_demo_full.box)
-        self.tables_demo_full.add_subtask(self.move_item, self.tables_demo_full.box, self.tables_demo_full.location)
+        s1 = self.tables_demo_full.add_subtask(self.search_tool, self.robot, self.tables_demo_full.tool)
+        s2 = self.tables_demo_full.add_subtask(self.get_item, self.tables_demo_full.tool)
+        s3 = self.tables_demo_full.add_subtask(self.search_box, self.robot)
+        s4 = self.tables_demo_full.add_subtask(self.insert_item, self.tables_demo_full.tool, self.tables_demo_full.box)
+        s5 = self.tables_demo_full.add_subtask(self.move_item, self.tables_demo_full.box, self.tables_demo_full.location)
+        self.tables_demo_full.set_ordered(s1, s2, s3, s4, s5)
 
         self.problem = self.define_mobipick_problem(
             fluents=(
@@ -889,7 +898,7 @@ class HierarchicalDomain(TablesDemoAPIDomain):
                 break
             if actions is None:
                 print("Execution ended because no plan could be found.")
-                return
+                break
 
         print("Demo complete.")
         if self.visualization:

--- a/tables_demo_planning/src/tables_demo_planning/hierarchical_domain.py
+++ b/tables_demo_planning/src/tables_demo_planning/hierarchical_domain.py
@@ -56,6 +56,7 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         self.perceive = Task("perceive", location=self.get_type(Location))
         self.get_item = Task("get_item", item=self.get_type(Item))
         self.put_item = Task("put_item", item=self.get_type(Item), location=self.get_type(Location))
+        self.move_item = Task("move_item", item=self.get_type(Item), location=self.get_type(Location))
 
         # METHODS
 
@@ -222,6 +223,18 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         )
         self.put_item_full.set_ordered(s1, s2)
 
+        # MOVE ITEM
+        # move item from one location to another location
+        self.move_item_full = Method(
+            "move_item_full", item=self.get_type(Item), location=self.get_type(Location), pose=self.get_type(Pose)
+        )
+        move_item_full_item = self.move_item_full.parameter("item")
+        move_item_full_loc = self.move_item_full.parameter("location")
+        self.move_item_full.set_task(self.move_item, move_item_full_item, move_item_full_loc)
+        s1 = self.move_item_full.add_subtask(self.get_item, move_item_full_item)
+        s2 = self.move_item_full.add_subtask(self.put_item, move_item_full_item, move_item_full_loc)
+        self.move_item_full.set_ordered(s1, s2)
+
         self.problem = self.define_mobipick_problem(
             fluents=(
                 self.robot_at,
@@ -258,6 +271,7 @@ class HierarchicalDomain(TablesDemoAPIDomain):
                 self.get_item_full,
                 self.put_item_place,
                 self.put_item_full,
+                self.move_item_full,
             ),
             tasks=(
                 self.drive,
@@ -265,6 +279,7 @@ class HierarchicalDomain(TablesDemoAPIDomain):
                 self.perceive,
                 self.get_item,
                 self.put_item,
+                self.move_item,
             ),
         )
         self.problem.add_quality_metric(MinimizeSequentialPlanLength())

--- a/tables_demo_planning/src/tables_demo_planning/hierarchical_domain.py
+++ b/tables_demo_planning/src/tables_demo_planning/hierarchical_domain.py
@@ -186,6 +186,12 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         self.get_item_full.set_ordered(s1, s2)
 
         # PUT ITEM
+        # item already at target location, robot is holding nothing
+        self.put_item_noop = Method("put_item_noop", item=type_item, location=type_location, pose=type_pose)
+        self.put_item_noop.set_task(self.put_item, self.put_item_noop.item, self.put_item_noop.location)
+        self.put_item_noop.add_precondition(self.robot_has(self.nothing))
+        self.put_item_noop.add_precondition(self.believe_item_at(self.put_item_noop.item, self.put_item_noop.location))
+
         # robot already at target pose, place item
         self.put_item_place = Method("put_item_place", item=type_item, location=type_location, pose=type_pose)
         self.put_item_place.set_task(self.put_item, self.put_item_place.item, self.put_item_place.location)
@@ -212,6 +218,13 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         self.put_item_full.set_ordered(s1, s2)
 
         # MOVE ITEM
+        # item already at location, nothing to do
+        self.move_item_noop = Method("move_item_noop", item=type_item, location=type_location)
+        self.move_item_noop.set_task(self.move_item, self.move_item_noop.item, self.move_item_noop.location)
+        self.move_item_noop.add_precondition(
+            self.believe_item_at(self.move_item_noop.item, self.move_item_noop.location)
+        )
+
         # move item from one location to another location
         self.move_item_full = Method("move_item_full", item=type_item, location=type_location)
         self.move_item_full.set_task(self.move_item, self.move_item_full.item, self.move_item_full.location)
@@ -363,104 +376,7 @@ class HierarchicalDomain(TablesDemoAPIDomain):
             self.believe_item_at(self.tables_demo_noop.box, self.tables_demo_noop.location)
         )
 
-        # tool in box, move to target table
-        self.tables_demo_move_box = Method(
-            "tables_demo_move_box", tool=type_item, box=type_item, location=type_location
-        )
-        self.tables_demo_move_box.set_task(
-            self.tables_demo,
-            self.tables_demo_move_box.tool,
-            self.tables_demo_move_box.box,
-            self.tables_demo_move_box.location,
-        )
-        self.tables_demo_move_box.add_precondition(self.believe_item_at(self.tables_demo_move_box.tool, self.in_box))
-        self.tables_demo_move_box.add_precondition(self.robot_has(self.nothing))
-        self.tables_demo_move_box.add_precondition(
-            Not(self.believe_item_at(self.tables_demo_move_box.box, self.tables_demo_move_box.location))
-        )
-        self.tables_demo_move_box.add_subtask(
-            self.move_item, self.tables_demo_move_box.box, self.tables_demo_move_box.location
-        )
-
-        # already holding tool, box on target table
-        self.tables_demo_insert_tool = Method(
-            "tables_demo_insert_tool",
-            tool=type_item,
-            box=type_item,
-            location=type_location,
-        )
-        self.tables_demo_insert_tool.set_task(
-            self.tables_demo,
-            self.tables_demo_insert_tool.tool,
-            self.tables_demo_insert_tool.box,
-            self.tables_demo_insert_tool.location,
-        )
-        self.tables_demo_insert_tool.add_precondition(
-            self.believe_item_at(self.tables_demo_insert_tool.tool, self.on_robot)
-        )
-        self.tables_demo_insert_tool.add_precondition(self.robot_has(self.tables_demo_insert_tool.tool))
-        self.tables_demo_insert_tool.add_precondition(
-            self.believe_item_at(self.tables_demo_insert_tool.box, self.tables_demo_insert_tool.location)
-        )
-        self.tables_demo_insert_tool.add_subtask(
-            self.insert_item, self.tables_demo_insert_tool.tool, self.tables_demo_insert_tool.box
-        )
-
-        # already holding tool, box location known
-        self.tables_demo_insert_tool_move = Method(
-            "tables_demo_insert_tool_move",
-            tool=type_item,
-            box=type_item,
-            location=type_location,
-        )
-        self.tables_demo_insert_tool_move.set_task(
-            self.tables_demo,
-            self.tables_demo_insert_tool_move.tool,
-            self.tables_demo_insert_tool_move.box,
-            self.tables_demo_insert_tool_move.location,
-        )
-        self.tables_demo_insert_tool_move.add_precondition(
-            self.believe_item_at(self.tables_demo_insert_tool_move.tool, self.on_robot)
-        )
-        self.tables_demo_insert_tool_move.add_precondition(self.robot_has(self.tables_demo_insert_tool_move.tool))
-        self.tables_demo_insert_tool_move.add_precondition(
-            Not(self.believe_item_at(self.tables_demo_insert_tool_move.box, self.anywhere))
-        )
-        s1 = self.tables_demo_insert_tool_move.add_subtask(
-            self.insert_item, self.tables_demo_insert_tool_move.tool, self.tables_demo_insert_tool_move.box
-        )
-        s2 = self.tables_demo_insert_tool_move.add_subtask(
-            self.move_item, self.tables_demo_insert_tool_move.box, self.tables_demo_insert_tool_move.location
-        )
-        self.tables_demo_insert_tool_move.set_ordered(s1, s2)
-
-        # already holding tool
-        self.tables_demo_search_box = Method(
-            "tables_demo_search_box",
-            tool=type_item,
-            box=type_item,
-            location=type_location,
-        )
-        self.tables_demo_search_box.set_task(
-            self.tables_demo,
-            self.tables_demo_search_box.tool,
-            self.tables_demo_search_box.box,
-            self.tables_demo_search_box.location,
-        )
-        self.tables_demo_search_box.add_precondition(
-            self.believe_item_at(self.tables_demo_search_box.tool, self.on_robot)
-        )
-        self.tables_demo_search_box.add_precondition(self.robot_has(self.tables_demo_search_box.tool))
-        s1 = self.tables_demo_search_box.add_subtask(self.search_box, self.robot)
-        s2 = self.tables_demo_search_box.add_subtask(
-            self.insert_item, self.tables_demo_search_box.tool, self.tables_demo_search_box.box
-        )
-        s3 = self.tables_demo_search_box.add_subtask(
-            self.move_item, self.tables_demo_search_box.box, self.tables_demo_search_box.location
-        )
-        self.tables_demo_search_box.set_ordered(s1, s2, s3)
-
-        # box location already known and on target table
+        # box location already known
         self.tables_demo_search_tool = Method(
             "tables_demo_search_tool",
             tool=type_item,
@@ -474,68 +390,68 @@ class HierarchicalDomain(TablesDemoAPIDomain):
             self.tables_demo_search_tool.location,
         )
         self.tables_demo_search_tool.add_precondition(
-            self.believe_item_at(self.tables_demo_search_tool.box, self.tables_demo_search_tool.location)
+            Not(self.believe_item_at(self.tables_demo_search_tool.box, self.anywhere))
+        )
+        self.tables_demo_search_tool.add_precondition(
+            Not(self.believe_item_at(self.tables_demo_search_tool.box, self.tables_demo_search_tool.location))
         )
         s1 = self.tables_demo_search_tool.add_subtask(self.search_tool, self.robot, self.tables_demo_search_tool.tool)
         s2 = self.tables_demo_search_tool.add_subtask(self.get_item, self.tables_demo_search_tool.tool)
         s3 = self.tables_demo_search_tool.add_subtask(
             self.insert_item, self.tables_demo_search_tool.tool, self.tables_demo_search_tool.box
         )
-        self.tables_demo_search_tool.set_ordered(s1, s2, s3)
-
-        # box location already known
-        self.tables_demo_search_tool_move = Method(
-            "tables_demo_search_tool_move",
-            tool=type_item,
-            box=type_item,
-            location=type_location,
+        s4 = self.tables_demo_search_tool.add_subtask(
+            self.move_item, self.tables_demo_search_tool.box, self.tables_demo_search_tool.location
         )
-        self.tables_demo_search_tool_move.set_task(
-            self.tables_demo,
-            self.tables_demo_search_tool_move.tool,
-            self.tables_demo_search_tool_move.box,
-            self.tables_demo_search_tool_move.location,
-        )
-        self.tables_demo_search_tool_move.add_precondition(
-            Not(self.believe_item_at(self.tables_demo_search_tool_move.box, self.anywhere))
-        )
-        self.tables_demo_search_tool_move.add_precondition(
-            Not(self.believe_item_at(self.tables_demo_search_tool_move.box, self.tables_demo_search_tool_move.location))
-        )
-        s1 = self.tables_demo_search_tool_move.add_subtask(
-            self.search_tool, self.robot, self.tables_demo_search_tool_move.tool
-        )
-        s2 = self.tables_demo_search_tool_move.add_subtask(self.get_item, self.tables_demo_search_tool_move.tool)
-        s3 = self.tables_demo_search_tool_move.add_subtask(
-            self.insert_item, self.tables_demo_search_tool_move.tool, self.tables_demo_search_tool_move.box
-        )
-        s4 = self.tables_demo_search_tool_move.add_subtask(
-            self.move_item, self.tables_demo_search_tool_move.box, self.tables_demo_search_tool_move.location
-        )
-        self.tables_demo_search_tool_move.set_ordered(s1, s2, s3, s4)
+        self.tables_demo_search_tool.set_ordered(s1, s2, s3, s4)
 
         # tool location already known
-        self.tables_demo_get_tool = Method(
-            "tables_demo_get_tool", tool=type_item, box=type_item, location=type_location
+        self.tables_demo_search_box = Method(
+            "tables_demo_search_box", tool=type_item, box=type_item, location=type_location
         )
-        self.tables_demo_get_tool.set_task(
+        self.tables_demo_search_box.set_task(
             self.tables_demo,
-            self.tables_demo_get_tool.tool,
-            self.tables_demo_get_tool.box,
-            self.tables_demo_get_tool.location,
+            self.tables_demo_search_box.tool,
+            self.tables_demo_search_box.box,
+            self.tables_demo_search_box.location,
         )
-        self.tables_demo_get_tool.add_precondition(
-            Not(self.believe_item_at(self.tables_demo_get_tool.tool, self.anywhere))
+        self.tables_demo_search_box.add_precondition(
+            Not(self.believe_item_at(self.tables_demo_search_box.tool, self.anywhere))
         )
-        s1 = self.tables_demo_get_tool.add_subtask(self.get_item, self.tables_demo_get_tool.tool)
-        s2 = self.tables_demo_get_tool.add_subtask(self.search_box, self.robot)
-        s3 = self.tables_demo_get_tool.add_subtask(
-            self.insert_item, self.tables_demo_get_tool.tool, self.tables_demo_get_tool.box
+        s1 = self.tables_demo_search_box.add_subtask(self.get_item, self.tables_demo_search_box.tool)
+        s2 = self.tables_demo_search_box.add_subtask(self.search_box, self.robot)
+        s3 = self.tables_demo_search_box.add_subtask(
+            self.insert_item, self.tables_demo_search_box.tool, self.tables_demo_search_box.box
         )
-        s4 = self.tables_demo_get_tool.add_subtask(
-            self.move_item, self.tables_demo_get_tool.box, self.tables_demo_get_tool.location
+        s4 = self.tables_demo_search_box.add_subtask(
+            self.move_item, self.tables_demo_search_box.box, self.tables_demo_search_box.location
         )
-        self.tables_demo_get_tool.set_ordered(s1, s2, s3, s4)
+        self.tables_demo_search_box.set_ordered(s1, s2, s3, s4)
+
+        # tool and box location already known, get item, insert into box and move to target table
+        self.tables_demo_move_item = Method(
+            "tables_demo_move_item", tool=type_item, box=type_item, location=type_location
+        )
+        self.tables_demo_move_item.set_task(
+            self.tables_demo,
+            self.tables_demo_move_item.tool,
+            self.tables_demo_move_item.box,
+            self.tables_demo_move_item.location,
+        )
+        self.tables_demo_move_item.add_precondition(
+            Not(self.believe_item_at(self.tables_demo_move_item.tool, self.anywhere))
+        )
+        self.tables_demo_move_item.add_precondition(
+            Not(self.believe_item_at(self.tables_demo_move_item.box, self.anywhere))
+        )
+        s1 = self.tables_demo_move_item.add_subtask(self.get_item, self.tables_demo_move_item.tool)
+        s2 = self.tables_demo_move_item.add_subtask(
+            self.insert_item, self.tables_demo_move_item.tool, self.tables_demo_move_item.box
+        )
+        s3 = self.tables_demo_move_item.add_subtask(
+            self.move_item, self.tables_demo_move_item.box, self.tables_demo_move_item.location
+        )
+        self.tables_demo_move_item.set_ordered(s1, s2, s3)
 
         # full tables demo
         self.tables_demo_full = Method("tables_demo_full", tool=type_item, box=type_item, location=type_location)
@@ -586,8 +502,10 @@ class HierarchicalDomain(TablesDemoAPIDomain):
                 self.get_item_noop,
                 self.get_item_pick,
                 self.get_item_full,
+                self.put_item_noop,
                 self.put_item_place,
                 self.put_item_full,
+                self.move_item_noop,
                 self.move_item_full,
                 self.bring_item_handover,
                 self.bring_item_drive,
@@ -598,14 +516,9 @@ class HierarchicalDomain(TablesDemoAPIDomain):
                 self.insert_item_drive,
                 self.insert_item_store,
                 self.insert_item_full,
-                self.tables_demo_noop,
-                self.tables_demo_move_box,
-                self.tables_demo_insert_tool,
-                self.tables_demo_insert_tool_move,
-                self.tables_demo_get_tool,
                 self.tables_demo_search_box,
                 self.tables_demo_search_tool,
-                self.tables_demo_search_tool_move,
+                self.tables_demo_move_item,
                 self.tables_demo_full,
             ),
             tasks=(

--- a/tables_demo_planning/src/tables_demo_planning/hierarchical_domain.py
+++ b/tables_demo_planning/src/tables_demo_planning/hierarchical_domain.py
@@ -53,32 +53,34 @@ class HierarchicalDomain(TablesDemoAPIDomain):
     def __init__(self) -> None:
         super().__init__()
 
+        # UP types
+        type_pose = self.get_type(Pose)
+        type_arm_pose = self.get_type(ArmPose)
+        type_location = self.get_type(Location)
+        type_item = self.get_type(Item)
+
         # TASKS
-        self.drive = Task("drive", goal_pose=self.get_type(Pose))
-        self.adapt_arm = Task("adapt_arm", to_pose=self.get_type(ArmPose))
-        self.perceive = Task("perceive", location=self.get_type(Location))
-        self.get_item = Task("get_item", item=self.get_type(Item))
-        self.put_item = Task("put_item", item=self.get_type(Item), location=self.get_type(Location))
-        self.move_item = Task("move_item", item=self.get_type(Item), location=self.get_type(Location))
-        self.insert_item = Task("insert_item", item=self.get_type(Item), box=self.get_type(Item))
-        self.bring_item = Task("bring_item", item=self.get_type(Item))
-        self.search_item = Task("search_item", item=self.get_type(Item))
-        self.tables_demo = Task(
-            "tables_demo", tool=self.get_type(Item), box=self.get_type(Item), location=self.get_type(Location)
-        )
+        self.drive = Task("drive", goal_pose=type_pose)
+        self.adapt_arm = Task("adapt_arm", to_pose=type_arm_pose)
+        self.perceive = Task("perceive", location=type_location)
+        self.get_item = Task("get_item", item=type_item)
+        self.put_item = Task("put_item", item=type_item, location=type_location)
+        self.move_item = Task("move_item", item=type_item, location=type_location)
+        self.insert_item = Task("insert_item", item=type_item, box=type_item)
+        self.bring_item = Task("bring_item", item=type_item)
+        self.search_item = Task("search_item", item=type_item)
+        self.tables_demo = Task("tables_demo", tool=type_item, box=type_item, location=type_location)
 
         # METHODS
 
         # DRIVE
         # robot already at goal pose
-        self.drive_noop = Method("drive_noop", goal_pose=self.get_type(Pose))
+        self.drive_noop = Method("drive_noop", goal_pose=type_pose)
         self.drive_noop.set_task(self.drive, self.drive_noop.goal_pose)
         self.drive_noop.add_precondition(self.robot_at(self.drive_noop.goal_pose))
 
         # arm not holding anything, move arm to home pose and move base to goal location
-        self.drive_homeposture = Method(
-            "drive_homeposture", start_pose=self.get_type(Pose), goal_pose=self.get_type(Pose)
-        )
+        self.drive_homeposture = Method("drive_homeposture", start_pose=type_pose, goal_pose=type_pose)
         self.drive_homeposture.set_task(self.drive, self.drive_homeposture.goal_pose)
         self.drive_homeposture.add_precondition(self.robot_at(self.drive_homeposture.start_pose))
         self.drive_homeposture.add_precondition(self.robot_has(self.nothing))
@@ -89,9 +91,7 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         self.drive_homeposture.set_ordered(s1, s2)
 
         # arm holding an item, move arm to transport pose and move base to goal location
-        self.drive_transport = Method(
-            "drive_transport", item=self.get_type(Item), start_pose=self.get_type(Pose), goal_pose=self.get_type(Pose)
-        )
+        self.drive_transport = Method("drive_transport", item=type_item, start_pose=type_pose, goal_pose=type_pose)
         self.drive_transport.set_task(self.drive, self.drive_transport.goal_pose)
         self.drive_transport.add_precondition(self.robot_at(self.drive_transport.start_pose))
         self.drive_transport.add_precondition(self.robot_has(self.drive_transport.item))
@@ -107,12 +107,12 @@ class HierarchicalDomain(TablesDemoAPIDomain):
 
         # ADAPT ARM
         # arm already in goal arm pose
-        self.adapt_arm_noop = Method("adapt_arm_noop", to_pose=self.get_type(ArmPose))
+        self.adapt_arm_noop = Method("adapt_arm_noop", to_pose=type_arm_pose)
         self.adapt_arm_noop.set_task(self.adapt_arm, self.adapt_arm_noop.to_pose)
         self.adapt_arm_noop.add_precondition(self.robot_arm_at(self.adapt_arm_noop.to_pose))
 
         # move arm to goal arm pose
-        self.adapt_arm_full = Method("adapt_arm_full", from_pose=self.get_type(ArmPose), to_pose=self.get_type(ArmPose))
+        self.adapt_arm_full = Method("adapt_arm_full", from_pose=type_arm_pose, to_pose=type_arm_pose)
         self.adapt_arm_full.set_task(self.adapt_arm, self.adapt_arm_full.to_pose)
         self.adapt_arm_full.add_precondition(self.robot_arm_at(self.adapt_arm_full.from_pose))
         self.adapt_arm_full.add_precondition(Not(Equals(self.adapt_arm_full.from_pose, self.adapt_arm_full.to_pose)))
@@ -122,12 +122,12 @@ class HierarchicalDomain(TablesDemoAPIDomain):
 
         # PERCEIVE LOCATION
         # already perceived location
-        self.perceive_noop = Method("perceive_noop", pose=self.get_type(Pose), location=self.get_type(Location))
+        self.perceive_noop = Method("perceive_noop", pose=type_pose, location=type_location)
         self.perceive_noop.set_task(self.perceive, self.perceive_noop.location)
         self.perceive_noop.add_precondition(self.searched_at(self.perceive_noop.location))
 
         # already at location, arm pose unknown
-        self.perceive_move_arm = Method("perceive_move_arm", pose=self.get_type(Pose), location=self.get_type(Location))
+        self.perceive_move_arm = Method("perceive_move_arm", pose=type_pose, location=type_location)
         self.perceive_move_arm.set_task(self.perceive, self.perceive_move_arm.location)
         self.perceive_move_arm.add_precondition(self.robot_at(self.perceive_move_arm.pose))
         self.perceive_move_arm.add_precondition(
@@ -140,7 +140,7 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         self.perceive_move_arm.set_ordered(s1, s2)
 
         # already at location, perceive location
-        self.perceive_location = Method("perceive_location", pose=self.get_type(Pose), location=self.get_type(Location))
+        self.perceive_location = Method("perceive_location", pose=type_pose, location=type_location)
         self.perceive_location.set_task(self.perceive, self.perceive_location.location)
         self.perceive_location.add_precondition(self.robot_at(self.perceive_location.pose))
         self.perceive_location.add_subtask(
@@ -148,7 +148,7 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         )
 
         # drive to location, perceive location
-        self.perceive_full = Method("perceive_full", pose=self.get_type(Pose), location=self.get_type(Location))
+        self.perceive_full = Method("perceive_full", pose=type_pose, location=type_location)
         self.perceive_full.set_task(self.perceive, self.perceive_full.location)
         s1 = self.perceive_full.add_subtask(self.drive, self.perceive_full.pose)
         s2 = self.perceive_full.add_subtask(
@@ -158,14 +158,12 @@ class HierarchicalDomain(TablesDemoAPIDomain):
 
         # GET ITEM
         # item already in robots gripper
-        self.get_item_noop = Method("get_item_noop", item=self.get_type(Item))
+        self.get_item_noop = Method("get_item_noop", item=type_item)
         self.get_item_noop.set_task(self.get_item, self.get_item_noop.item)
         self.get_item_noop.add_precondition(self.robot_has(self.get_item_noop.item))
 
         # not holding an item, robot already at item location, pick up item
-        self.get_item_pick = Method(
-            "get_item_pick", item=self.get_type(Item), location=self.get_type(Location), pose=self.get_type(Pose)
-        )
+        self.get_item_pick = Method("get_item_pick", item=type_item, location=type_location, pose=type_pose)
         self.get_item_pick.set_task(self.get_item, self.get_item_pick.item)
         self.get_item_pick.add_precondition(self.robot_at(self.get_item_pick.pose))
         self.get_item_pick.add_precondition(self.robot_has(self.nothing))
@@ -176,9 +174,7 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         )
 
         # not holding an item, go to item location and pick up item
-        self.get_item_full = Method(
-            "get_item_full", item=self.get_type(Item), location=self.get_type(Location), pose=self.get_type(Pose)
-        )
+        self.get_item_full = Method("get_item_full", item=type_item, location=type_location, pose=type_pose)
         self.get_item_full.set_task(self.get_item, self.get_item_full.item)
         self.get_item_full.add_precondition(self.robot_has(self.nothing))
         self.get_item_full.add_precondition(self.believe_item_at(self.get_item_full.item, self.get_item_full.location))
@@ -191,9 +187,7 @@ class HierarchicalDomain(TablesDemoAPIDomain):
 
         # PUT ITEM
         # robot already at target pose, place item
-        self.put_item_place = Method(
-            "put_item_place", item=self.get_type(Item), location=self.get_type(Location), pose=self.get_type(Pose)
-        )
+        self.put_item_place = Method("put_item_place", item=type_item, location=type_location, pose=type_pose)
         self.put_item_place.set_task(self.put_item, self.put_item_place.item, self.put_item_place.location)
         self.put_item_place.add_precondition(self.robot_has(self.put_item_place.item))
         self.put_item_place.add_precondition(self.pose_at(self.put_item_place.pose, self.put_item_place.location))
@@ -207,9 +201,7 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         )
 
         # robot drives to target pose and places item
-        self.put_item_full = Method(
-            "put_item_full", item=self.get_type(Item), location=self.get_type(Location), pose=self.get_type(Pose)
-        )
+        self.put_item_full = Method("put_item_full", item=type_item, location=type_location, pose=type_pose)
         self.put_item_full.set_task(self.put_item, self.put_item_full.item, self.put_item_full.location)
         self.put_item_full.add_precondition(self.robot_has(self.put_item_full.item))
         self.put_item_full.add_precondition(self.pose_at(self.put_item_full.pose, self.put_item_full.location))
@@ -221,7 +213,7 @@ class HierarchicalDomain(TablesDemoAPIDomain):
 
         # MOVE ITEM
         # move item from one location to another location
-        self.move_item_full = Method("move_item_full", item=self.get_type(Item), location=self.get_type(Location))
+        self.move_item_full = Method("move_item_full", item=type_item, location=type_location)
         self.move_item_full.set_task(self.move_item, self.move_item_full.item, self.move_item_full.location)
         s1 = self.move_item_full.add_subtask(self.get_item, self.move_item_full.item)
         s2 = self.move_item_full.add_subtask(self.put_item, self.move_item_full.item, self.move_item_full.location)
@@ -231,10 +223,10 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         # item already in box
         self.insert_item_noop = Method(
             "insert_item_noop",
-            item=self.get_type(Item),
-            box=self.get_type(Item),
-            box_pose=self.get_type(Pose),
-            box_loc=self.get_type(Location),
+            item=type_item,
+            box=type_item,
+            box_pose=type_pose,
+            box_loc=type_location,
         )
         self.insert_item_noop.set_task(self.insert_item, self.insert_item_noop.item, self.insert_item_noop.box)
         self.insert_item_noop.add_precondition(self.believe_item_at(self.insert_item_noop.item, self.in_box))
@@ -242,10 +234,10 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         # already at box location, store item
         self.insert_item_store = Method(
             "insert_item_store",
-            item=self.get_type(Item),
-            box=self.get_type(Item),
-            box_pose=self.get_type(Pose),
-            box_loc=self.get_type(Location),
+            item=type_item,
+            box=type_item,
+            box_pose=type_pose,
+            box_loc=type_location,
         )
         self.insert_item_store.set_task(self.insert_item, self.insert_item_store.item, self.insert_item_store.box)
         self.insert_item_store.add_precondition(Not(self.believe_item_at(self.insert_item_store.box, self.anywhere)))
@@ -267,10 +259,10 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         # already holding item, move to box and insert
         self.insert_item_drive = Method(
             "insert_item_drive",
-            item=self.get_type(Item),
-            box=self.get_type(Item),
-            box_pose=self.get_type(Pose),
-            box_loc=self.get_type(Location),
+            item=type_item,
+            box=type_item,
+            box_pose=type_pose,
+            box_loc=type_location,
         )
         self.insert_item_drive.set_task(self.insert_item, self.insert_item_drive.item, self.insert_item_drive.box)
         self.insert_item_drive.add_precondition(Not(self.believe_item_at(self.insert_item_drive.box, self.anywhere)))
@@ -291,10 +283,10 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         # go to item location, pickup item, go to box location, store item in box
         self.insert_item_full = Method(
             "insert_item_full",
-            item=self.get_type(Item),
-            box=self.get_type(Item),
-            box_pose=self.get_type(Pose),
-            box_loc=self.get_type(Location),
+            item=type_item,
+            box=type_item,
+            box_pose=type_pose,
+            box_loc=type_location,
         )
         self.insert_item_full.set_task(self.insert_item, self.insert_item_full.item, self.insert_item_full.box)
         self.insert_item_full.add_precondition(Not(self.believe_item_at(self.insert_item_full.box, self.anywhere)))
@@ -314,7 +306,7 @@ class HierarchicalDomain(TablesDemoAPIDomain):
 
         # BRING ITEM
         # robot already has item and is at handover pose, hand item over, move arm to home pose
-        self.bring_item_handover = Method("bring_item_handover", item=self.get_type(Item))
+        self.bring_item_handover = Method("bring_item_handover", item=type_item)
         self.bring_item_handover.set_task(self.bring_item, self.bring_item_handover.item)
         self.bring_item_handover.add_precondition(self.robot_has(self.bring_item_handover.item))
         self.bring_item_handover.add_precondition(self.robot_at(self.base_handover_pose))
@@ -325,7 +317,7 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         self.bring_item_handover.set_ordered(s1, s2)
 
         # robot already has item, move to handover pose, hand item over, move arm to home pose
-        self.bring_item_drive = Method("bring_item_drive", item=self.get_type(Item))
+        self.bring_item_drive = Method("bring_item_drive", item=type_item)
         self.bring_item_drive.set_task(self.bring_item, self.bring_item_drive.item)
         self.bring_item_drive.add_precondition(self.robot_has(self.bring_item_drive.item))
         s1 = self.bring_item_drive.add_subtask(self.drive, self.base_handover_pose)
@@ -336,7 +328,7 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         self.bring_item_drive.set_ordered(s1, s2, s3)
 
         # go to item location, pick up item, go to handover pose, hand item over, move arm to home pose
-        self.bring_item_full = Method("bring_item_full", item=self.get_type(Item))
+        self.bring_item_full = Method("bring_item_full", item=type_item)
         self.bring_item_full.set_task(self.bring_item, self.bring_item_full.item)
         s1 = self.bring_item_full.add_subtask(self.get_item, self.bring_item_full.item)
         s2 = self.bring_item_full.add_subtask(self.drive, self.base_handover_pose)
@@ -348,12 +340,12 @@ class HierarchicalDomain(TablesDemoAPIDomain):
 
         # SEARCH ITEM
         # item location already known, nothing to do
-        self.search_item_noop = Method("search_item_noop", item=self.get_type(Item))
+        self.search_item_noop = Method("search_item_noop", item=type_item)
         self.search_item_noop.set_task(self.search_item, self.search_item_noop.item)
         self.search_item_noop.add_precondition(Not(self.believe_item_at(self.search_item_noop.item, self.anywhere)))
 
         # full search
-        self.search_item_full = Method("search_item_full", item=self.get_type(Item))
+        self.search_item_full = Method("search_item_full", item=type_item)
         self.search_item_full.set_task(self.search_item, self.search_item_full.item)
         self.search_item_full.add_precondition(self.believe_item_at(self.search_item_full.item, self.anywhere))
         for location in self.TABLE_LOCATIONS:
@@ -361,9 +353,7 @@ class HierarchicalDomain(TablesDemoAPIDomain):
 
         # TABLES DEMO
         # tool in box on target table, nothing to do
-        self.tables_demo_noop = Method(
-            "tables_demo_noop", tool=self.get_type(Item), box=self.get_type(Item), location=self.get_type(Location)
-        )
+        self.tables_demo_noop = Method("tables_demo_noop", tool=type_item, box=type_item, location=type_location)
         self.tables_demo_noop.set_task(
             self.tables_demo, self.tables_demo_noop.tool, self.tables_demo_noop.box, self.tables_demo_noop.location
         )
@@ -375,7 +365,7 @@ class HierarchicalDomain(TablesDemoAPIDomain):
 
         # tool in box, move to target table
         self.tables_demo_move_box = Method(
-            "tables_demo_move_box", tool=self.get_type(Item), box=self.get_type(Item), location=self.get_type(Location)
+            "tables_demo_move_box", tool=type_item, box=type_item, location=type_location
         )
         self.tables_demo_move_box.set_task(
             self.tables_demo,
@@ -395,9 +385,9 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         # already holding tool, box on target table
         self.tables_demo_insert_tool = Method(
             "tables_demo_insert_tool",
-            tool=self.get_type(Item),
-            box=self.get_type(Item),
-            location=self.get_type(Location),
+            tool=type_item,
+            box=type_item,
+            location=type_location,
         )
         self.tables_demo_insert_tool.set_task(
             self.tables_demo,
@@ -419,9 +409,9 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         # already holding tool, box location known
         self.tables_demo_insert_tool_move = Method(
             "tables_demo_insert_tool_move",
-            tool=self.get_type(Item),
-            box=self.get_type(Item),
-            location=self.get_type(Location),
+            tool=type_item,
+            box=type_item,
+            location=type_location,
         )
         self.tables_demo_insert_tool_move.set_task(
             self.tables_demo,
@@ -447,9 +437,9 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         # already holding tool
         self.tables_demo_search_box = Method(
             "tables_demo_search_box",
-            tool=self.get_type(Item),
-            box=self.get_type(Item),
-            location=self.get_type(Location),
+            tool=type_item,
+            box=type_item,
+            location=type_location,
         )
         self.tables_demo_search_box.set_task(
             self.tables_demo,
@@ -473,9 +463,9 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         # box location already known and on target table
         self.tables_demo_search_tool = Method(
             "tables_demo_search_tool",
-            tool=self.get_type(Item),
-            box=self.get_type(Item),
-            location=self.get_type(Location),
+            tool=type_item,
+            box=type_item,
+            location=type_location,
         )
         self.tables_demo_search_tool.set_task(
             self.tables_demo,
@@ -496,9 +486,9 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         # box location already known
         self.tables_demo_search_tool_move = Method(
             "tables_demo_search_tool_move",
-            tool=self.get_type(Item),
-            box=self.get_type(Item),
-            location=self.get_type(Location),
+            tool=type_item,
+            box=type_item,
+            location=type_location,
         )
         self.tables_demo_search_tool_move.set_task(
             self.tables_demo,
@@ -526,7 +516,7 @@ class HierarchicalDomain(TablesDemoAPIDomain):
 
         # tool location already known
         self.tables_demo_get_tool = Method(
-            "tables_demo_get_tool", tool=self.get_type(Item), box=self.get_type(Item), location=self.get_type(Location)
+            "tables_demo_get_tool", tool=type_item, box=type_item, location=type_location
         )
         self.tables_demo_get_tool.set_task(
             self.tables_demo,
@@ -548,9 +538,7 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         self.tables_demo_get_tool.set_ordered(s1, s2, s3, s4)
 
         # full tables demo
-        self.tables_demo_full = Method(
-            "tables_demo_full", tool=self.get_type(Item), box=self.get_type(Item), location=self.get_type(Location)
-        )
+        self.tables_demo_full = Method("tables_demo_full", tool=type_item, box=type_item, location=type_location)
         self.tables_demo_full.set_task(
             self.tables_demo, self.tables_demo_full.tool, self.tables_demo_full.box, self.tables_demo_full.location
         )
@@ -558,7 +546,9 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         s2 = self.tables_demo_full.add_subtask(self.get_item, self.tables_demo_full.tool)
         s3 = self.tables_demo_full.add_subtask(self.search_box, self.robot)
         s4 = self.tables_demo_full.add_subtask(self.insert_item, self.tables_demo_full.tool, self.tables_demo_full.box)
-        s5 = self.tables_demo_full.add_subtask(self.move_item, self.tables_demo_full.box, self.tables_demo_full.location)
+        s5 = self.tables_demo_full.add_subtask(
+            self.move_item, self.tables_demo_full.box, self.tables_demo_full.location
+        )
         self.tables_demo_full.set_ordered(s1, s2, s3, s4, s5)
 
         self.problem = self.define_mobipick_problem(

--- a/tables_demo_planning/src/tables_demo_planning/hierarchical_domain.py
+++ b/tables_demo_planning/src/tables_demo_planning/hierarchical_domain.py
@@ -57,6 +57,7 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         self.get_item = Task("get_item", item=self.get_type(Item))
         self.put_item = Task("put_item", item=self.get_type(Item), location=self.get_type(Location))
         self.move_item = Task("move_item", item=self.get_type(Item), location=self.get_type(Location))
+        self.insert_item = Task("insert_item", item=self.get_type(Item), box=self.get_type(Item))
         self.bring_item = Task("bring_item", item=self.get_type(Item))
 
         # METHODS
@@ -64,22 +65,19 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         # DRIVE
         # robot already at goal pose
         self.drive_noop = Method("drive_noop", goal_pose=self.get_type(Pose))
-        drive_noop_goal_pose = self.drive_noop.parameter("goal_pose")
-        self.drive_noop.set_task(self.drive, drive_noop_goal_pose)
-        self.drive_noop.add_precondition(self.robot_at(drive_noop_goal_pose))
+        self.drive_noop.set_task(self.drive, self.drive_noop.goal_pose)
+        self.drive_noop.add_precondition(self.robot_at(self.drive_noop.goal_pose))
 
         # arm not holding anything, move arm to home pose and move base to goal location
         self.drive_homeposture = Method(
             "drive_homeposture", start_pose=self.get_type(Pose), goal_pose=self.get_type(Pose)
         )
-        drive_homeposture_start_pose = self.drive_homeposture.parameter("start_pose")
-        drive_homeposture_goal_pose = self.drive_homeposture.parameter("goal_pose")
-        self.drive_homeposture.set_task(self.drive, drive_homeposture_goal_pose)
-        self.drive_homeposture.add_precondition(self.robot_at(drive_homeposture_start_pose))
+        self.drive_homeposture.set_task(self.drive, self.drive_homeposture.goal_pose)
+        self.drive_homeposture.add_precondition(self.robot_at(self.drive_homeposture.start_pose))
         self.drive_homeposture.add_precondition(self.robot_has(self.nothing))
         s1 = self.drive_homeposture.add_subtask(self.adapt_arm, self.arm_pose_home)
         s2 = self.drive_homeposture.add_subtask(
-            self.move_base, self.robot, drive_homeposture_start_pose, drive_homeposture_goal_pose
+            self.move_base, self.robot, self.drive_homeposture.start_pose, self.drive_homeposture.goal_pose
         )
         self.drive_homeposture.set_ordered(s1, s2)
 
@@ -87,108 +85,100 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         self.drive_transport = Method(
             "drive_transport", item=self.get_type(Item), start_pose=self.get_type(Pose), goal_pose=self.get_type(Pose)
         )
-        drive_transport_start_pose = self.drive_transport.parameter("start_pose")
-        drive_transport_goal_pose = self.drive_transport.parameter("goal_pose")
-        drive_transport_item = self.drive_transport.parameter("item")
-        self.drive_transport.set_task(self.drive, drive_transport_goal_pose)
-        self.drive_transport.add_precondition(self.robot_at(drive_transport_start_pose))
-        self.drive_transport.add_precondition(self.robot_has(drive_transport_item))
+        self.drive_transport.set_task(self.drive, self.drive_transport.goal_pose)
+        self.drive_transport.add_precondition(self.robot_at(self.drive_transport.start_pose))
+        self.drive_transport.add_precondition(self.robot_has(self.drive_transport.item))
         s1 = self.drive_transport.add_subtask(self.adapt_arm, self.arm_pose_transport)
         s2 = self.drive_transport.add_subtask(
             self.move_base_with_item,
             self.robot,
-            drive_transport_item,
-            drive_transport_start_pose,
-            drive_transport_goal_pose,
+            self.drive_transport.item,
+            self.drive_transport.start_pose,
+            self.drive_transport.goal_pose,
         )
         self.drive_transport.set_ordered(s1, s2)
 
         # ADAPT ARM
         # arm already in goal arm pose
         self.adapt_arm_noop = Method("adapt_arm_noop", to_pose=self.get_type(ArmPose))
-        adapt_arm_noop_to = self.adapt_arm_noop.parameter("to_pose")
-        self.adapt_arm_noop.set_task(self.adapt_arm, adapt_arm_noop_to)
-        self.adapt_arm_noop.add_precondition(self.robot_arm_at(adapt_arm_noop_to))
+        self.adapt_arm_noop.set_task(self.adapt_arm, self.adapt_arm_noop.to_pose)
+        self.adapt_arm_noop.add_precondition(self.robot_arm_at(self.adapt_arm_noop.to_pose))
 
         # move arm to goal arm pose
         self.adapt_arm_full = Method("adapt_arm_full", from_pose=self.get_type(ArmPose), to_pose=self.get_type(ArmPose))
-        adapt_arm_full_from = self.adapt_arm_full.parameter("from_pose")
-        adapt_arm_full_to = self.adapt_arm_full.parameter("to_pose")
-        self.adapt_arm_full.set_task(self.adapt_arm, adapt_arm_full_to)
-        self.adapt_arm_full.add_precondition(self.robot_arm_at(adapt_arm_full_from))
-        self.adapt_arm_full.add_precondition(Not(Equals(adapt_arm_full_from, adapt_arm_full_to)))
-        self.adapt_arm_full.add_subtask(self.move_arm, self.robot, adapt_arm_full_from, adapt_arm_full_to)
+        self.adapt_arm_full.set_task(self.adapt_arm, self.adapt_arm_full.to_pose)
+        self.adapt_arm_full.add_precondition(self.robot_arm_at(self.adapt_arm_full.from_pose))
+        self.adapt_arm_full.add_precondition(Not(Equals(self.adapt_arm_full.from_pose, self.adapt_arm_full.to_pose)))
+        self.adapt_arm_full.add_subtask(
+            self.move_arm, self.robot, self.adapt_arm_full.from_pose, self.adapt_arm_full.to_pose
+        )
 
         # PERCEIVE LOCATION
+        # already perceived location
+        self.perceive_noop = Method("perceive_noop", pose=self.get_type(Pose), location=self.get_type(Location))
+        self.perceive_noop.set_task(self.perceive, self.perceive_noop.location)
+        self.perceive_noop.add_precondition(self.searched_at(self.perceive_noop.location))
+
         # already at location, arm pose unknown
         self.perceive_move_arm = Method("perceive_move_arm", pose=self.get_type(Pose), location=self.get_type(Location))
-        perceive_move_arm_pose = self.perceive_move_arm.parameter("pose")
-        perceive_move_arm_loc = self.perceive_move_arm.parameter("location")
-        self.perceive_move_arm.set_task(self.perceive, perceive_move_arm_loc)
-        self.perceive_move_arm.add_precondition(self.robot_at(perceive_move_arm_pose))
+        self.perceive_move_arm.set_task(self.perceive, self.perceive_move_arm.location)
+        self.perceive_move_arm.add_precondition(self.robot_at(self.perceive_move_arm.pose))
         self.perceive_move_arm.add_precondition(
             Or(self.robot_arm_at(arm_pose) for arm_pose in (self.arm_pose_handover, self.arm_pose_unknown))
         )
         s1 = self.perceive_move_arm.add_subtask(self.adapt_arm, self.arm_pose_observe)
         s2 = self.perceive_move_arm.add_subtask(
-            self.search_at, self.robot, perceive_move_arm_pose, perceive_move_arm_loc
+            self.search_at, self.robot, self.perceive_move_arm.pose, self.perceive_move_arm.location
         )
         self.perceive_move_arm.set_ordered(s1, s2)
 
         # already at location, perceive location
         self.perceive_location = Method("perceive_location", pose=self.get_type(Pose), location=self.get_type(Location))
-        perceive_location_pose = self.perceive_location.parameter("pose")
-        perceive_location_loc = self.perceive_location.parameter("location")
-        self.perceive_location.set_task(self.perceive, perceive_location_loc)
-        self.perceive_location.add_precondition(self.robot_at(perceive_location_pose))
-        self.perceive_location.add_subtask(self.search_at, self.robot, perceive_location_pose, perceive_location_loc)
+        self.perceive_location.set_task(self.perceive, self.perceive_location.location)
+        self.perceive_location.add_precondition(self.robot_at(self.perceive_location.pose))
+        self.perceive_location.add_subtask(
+            self.search_at, self.robot, self.perceive_location.pose, self.perceive_location.location
+        )
 
         # drive to location, perceive location
         self.perceive_full = Method("perceive_full", pose=self.get_type(Pose), location=self.get_type(Location))
-        perceive_full_pose = self.perceive_full.parameter("pose")
-        perceive_full_loc = self.perceive_full.parameter("location")
-        self.perceive_full.set_task(self.perceive, perceive_full_loc)
-        s1 = self.perceive_full.add_subtask(self.drive, perceive_full_pose)
-        s2 = self.perceive_full.add_subtask(self.search_at, self.robot, perceive_full_pose, perceive_full_loc)
+        self.perceive_full.set_task(self.perceive, self.perceive_full.location)
+        s1 = self.perceive_full.add_subtask(self.drive, self.perceive_full.pose)
+        s2 = self.perceive_full.add_subtask(
+            self.search_at, self.robot, self.perceive_full.pose, self.perceive_full.location
+        )
         self.perceive_full.set_ordered(s1, s2)
 
         # GET ITEM
         # item already in robots gripper
         self.get_item_noop = Method("get_item_noop", item=self.get_type(Item))
-        get_item_noop_item = self.get_item_noop.parameter("item")
-        self.get_item_noop.set_task(self.get_item, get_item_noop_item)
-        self.get_item_noop.add_precondition(self.robot_has(get_item_noop_item))
+        self.get_item_noop.set_task(self.get_item, self.get_item_noop.item)
+        self.get_item_noop.add_precondition(self.robot_has(self.get_item_noop.item))
 
         # not holding an item, robot already at item location, pick up item
         self.get_item_pick = Method(
-            "get_item_pick", item=self.get_type(Item), item_loc=self.get_type(Location), pose=self.get_type(Pose)
+            "get_item_pick", item=self.get_type(Item), location=self.get_type(Location), pose=self.get_type(Pose)
         )
-        get_item_pick_item = self.get_item_pick.parameter("item")
-        get_item_pick_loc = self.get_item_pick.parameter("item_loc")
-        get_item_pick_pose = self.get_item_pick.parameter("pose")
-        self.get_item_pick.set_task(self.get_item, get_item_pick_item)
-        self.get_item_pick.add_precondition(self.robot_at(get_item_pick_pose))
+        self.get_item_pick.set_task(self.get_item, self.get_item_pick.item)
+        self.get_item_pick.add_precondition(self.robot_at(self.get_item_pick.pose))
         self.get_item_pick.add_precondition(self.robot_has(self.nothing))
-        self.get_item_pick.add_precondition(self.believe_item_at(get_item_pick_item, get_item_pick_loc))
-        self.get_item_pick.add_precondition(self.pose_at(get_item_pick_pose, get_item_pick_loc))
+        self.get_item_pick.add_precondition(self.believe_item_at(self.get_item_pick.item, self.get_item_pick.location))
+        self.get_item_pick.add_precondition(self.pose_at(self.get_item_pick.pose, self.get_item_pick.location))
         self.get_item_pick.add_subtask(
-            self.pick_item, self.robot, get_item_pick_pose, get_item_pick_loc, get_item_pick_item
+            self.pick_item, self.robot, self.get_item_pick.pose, self.get_item_pick.location, self.get_item_pick.item
         )
 
         # not holding an item, go to item location and pick up item
         self.get_item_full = Method(
-            "get_item_full", item=self.get_type(Item), item_loc=self.get_type(Location), to_pose=self.get_type(Pose)
+            "get_item_full", item=self.get_type(Item), location=self.get_type(Location), pose=self.get_type(Pose)
         )
-        get_item_full_item = self.get_item_full.parameter("item")
-        get_item_full_loc = self.get_item_full.parameter("item_loc")
-        get_item_full_to_pose = self.get_item_full.parameter("to_pose")
-        self.get_item_full.set_task(self.get_item, get_item_full_item)
+        self.get_item_full.set_task(self.get_item, self.get_item_full.item)
         self.get_item_full.add_precondition(self.robot_has(self.nothing))
-        self.get_item_full.add_precondition(self.believe_item_at(get_item_full_item, get_item_full_loc))
-        self.get_item_full.add_precondition(self.pose_at(get_item_full_to_pose, get_item_full_loc))
-        s1 = self.get_item_full.add_subtask(self.drive, get_item_full_to_pose)
+        self.get_item_full.add_precondition(self.believe_item_at(self.get_item_full.item, self.get_item_full.location))
+        self.get_item_full.add_precondition(self.pose_at(self.get_item_full.pose, self.get_item_full.location))
+        s1 = self.get_item_full.add_subtask(self.drive, self.get_item_full.pose)
         s2 = self.get_item_full.add_subtask(
-            self.pick_item, self.robot, get_item_full_to_pose, get_item_full_loc, get_item_full_item
+            self.pick_item, self.robot, self.get_item_full.pose, self.get_item_full.location, self.get_item_full.item
         )
         self.get_item_full.set_ordered(s1, s2)
 
@@ -197,78 +187,151 @@ class HierarchicalDomain(TablesDemoAPIDomain):
         self.put_item_place = Method(
             "put_item_place", item=self.get_type(Item), location=self.get_type(Location), pose=self.get_type(Pose)
         )
-        put_item_place_item = self.put_item_place.parameter("item")
-        put_item_place_location = self.put_item_place.parameter("location")
-        put_item_place_pose = self.put_item_place.parameter("pose")
-        self.put_item_place.set_task(self.put_item, put_item_place_item, put_item_place_location)
-        self.put_item_place.add_precondition(self.robot_has(put_item_place_item))
-        self.put_item_place.add_precondition(self.pose_at(put_item_place_pose, put_item_place_location))
-        self.put_item_place.add_precondition(self.robot_at(put_item_place_pose))
+        self.put_item_place.set_task(self.put_item, self.put_item_place.item, self.put_item_place.location)
+        self.put_item_place.add_precondition(self.robot_has(self.put_item_place.item))
+        self.put_item_place.add_precondition(self.pose_at(self.put_item_place.pose, self.put_item_place.location))
+        self.put_item_place.add_precondition(self.robot_at(self.put_item_place.pose))
         self.put_item_place.add_subtask(
-            self.place_item, self.robot, put_item_place_pose, put_item_place_location, put_item_place_item
+            self.place_item,
+            self.robot,
+            self.put_item_place.pose,
+            self.put_item_place.location,
+            self.put_item_place.item,
         )
 
         # robot drives to target pose and places item
         self.put_item_full = Method(
             "put_item_full", item=self.get_type(Item), location=self.get_type(Location), pose=self.get_type(Pose)
         )
-        put_item_full_item = self.put_item_full.parameter("item")
-        put_item_full_location = self.put_item_full.parameter("location")
-        put_item_full_pose = self.put_item_full.parameter("pose")
-        self.put_item_full.set_task(self.put_item, put_item_full_item, put_item_full_location)
-        self.put_item_full.add_precondition(self.robot_has(put_item_full_item))
-        self.put_item_full.add_precondition(self.pose_at(put_item_full_pose, put_item_full_location))
-        s1 = self.put_item_full.add_subtask(self.drive, put_item_full_pose)
+        self.put_item_full.set_task(self.put_item, self.put_item_full.item, self.put_item_full.location)
+        self.put_item_full.add_precondition(self.robot_has(self.put_item_full.item))
+        self.put_item_full.add_precondition(self.pose_at(self.put_item_full.pose, self.put_item_full.location))
+        s1 = self.put_item_full.add_subtask(self.drive, self.put_item_full.pose)
         s2 = self.put_item_full.add_subtask(
-            self.place_item, self.robot, put_item_full_pose, put_item_full_location, put_item_full_item
+            self.place_item, self.robot, self.put_item_full.pose, self.put_item_full.location, self.put_item_full.item
         )
         self.put_item_full.set_ordered(s1, s2)
 
         # MOVE ITEM
         # move item from one location to another location
-        self.move_item_full = Method(
-            "move_item_full", item=self.get_type(Item), location=self.get_type(Location), pose=self.get_type(Pose)
-        )
-        move_item_full_item = self.move_item_full.parameter("item")
-        move_item_full_loc = self.move_item_full.parameter("location")
-        self.move_item_full.set_task(self.move_item, move_item_full_item, move_item_full_loc)
-        s1 = self.move_item_full.add_subtask(self.get_item, move_item_full_item)
-        s2 = self.move_item_full.add_subtask(self.put_item, move_item_full_item, move_item_full_loc)
+        self.move_item_full = Method("move_item_full", item=self.get_type(Item), location=self.get_type(Location))
+        self.move_item_full.set_task(self.move_item, self.move_item_full.item, self.move_item_full.location)
+        s1 = self.move_item_full.add_subtask(self.get_item, self.move_item_full.item)
+        s2 = self.move_item_full.add_subtask(self.put_item, self.move_item_full.item, self.move_item_full.location)
         self.move_item_full.set_ordered(s1, s2)
+
+        # INSERT ITEM
+        # item already in box
+        self.insert_item_noop = Method(
+            "insert_item_noop",
+            item=self.get_type(Item),
+            box=self.get_type(Item),
+            box_pose=self.get_type(Pose),
+            box_loc=self.get_type(Location),
+        )
+        self.insert_item_noop.set_task(self.insert_item, self.insert_item_noop.item, self.insert_item_noop.box)
+        self.insert_item_noop.add_precondition(self.believe_item_at(self.insert_item_noop.item, self.in_box))
+
+        # already at box location, store item
+        self.insert_item_store = Method(
+            "insert_item_store",
+            item=self.get_type(Item),
+            box=self.get_type(Item),
+            box_pose=self.get_type(Pose),
+            box_loc=self.get_type(Location),
+        )
+        self.insert_item_store.set_task(self.insert_item, self.insert_item_store.item, self.insert_item_store.box)
+        self.insert_item_store.add_precondition(Not(self.believe_item_at(self.insert_item_store.box, self.anywhere)))
+        self.insert_item_store.add_precondition(
+            self.pose_at(self.insert_item_store.box_pose, self.insert_item_store.box_loc)
+        )
+        self.insert_item_store.add_precondition(self.robot_has(self.insert_item_store.item))
+        self.insert_item_store.add_precondition(self.robot_at(self.insert_item_store.box_pose))
+        self.insert_item_store.add_subtask(self.drive, self.insert_item_store.box_pose)
+        self.insert_item_store.add_subtask(
+            self.store_item,
+            self.robot,
+            self.insert_item_store.box_pose,
+            self.insert_item_store.box_loc,
+            self.insert_item_store.item,
+        )
+
+        # already holding item, move to box and insert
+        self.insert_item_drive = Method(
+            "insert_item_drive",
+            item=self.get_type(Item),
+            box=self.get_type(Item),
+            box_pose=self.get_type(Pose),
+            box_loc=self.get_type(Location),
+        )
+        self.insert_item_drive.set_task(self.insert_item, self.insert_item_drive.item, self.insert_item_drive.box)
+        self.insert_item_drive.add_precondition(Not(self.believe_item_at(self.insert_item_drive.box, self.anywhere)))
+        self.insert_item_drive.add_precondition(
+            self.pose_at(self.insert_item_drive.box_pose, self.insert_item_drive.box_loc)
+        )
+        self.insert_item_drive.add_precondition(self.robot_has(self.insert_item_drive.item))
+        self.insert_item_drive.add_subtask(self.drive, self.insert_item_drive.box_pose)
+        self.insert_item_drive.add_subtask(
+            self.store_item,
+            self.robot,
+            self.insert_item_drive.box_pose,
+            self.insert_item_drive.box_loc,
+            self.insert_item_drive.item,
+        )
+
+        # go to item location, pickup item, go to box location, store item in box
+        self.insert_item_full = Method(
+            "insert_item_full",
+            item=self.get_type(Item),
+            box=self.get_type(Item),
+            box_pose=self.get_type(Pose),
+            box_loc=self.get_type(Location),
+        )
+        self.insert_item_full.set_task(self.insert_item, self.insert_item_full.item, self.insert_item_full.box)
+        self.insert_item_full.add_precondition(Not(self.believe_item_at(self.insert_item_full.box, self.anywhere)))
+        self.insert_item_full.add_precondition(
+            self.pose_at(self.insert_item_full.box_pose, self.insert_item_full.box_loc)
+        )
+        self.insert_item_full.add_subtask(self.get_item, self.insert_item_full.item)
+        self.insert_item_full.add_subtask(self.drive, self.insert_item_full.box_pose)
+        self.insert_item_full.add_subtask(
+            self.store_item,
+            self.robot,
+            self.insert_item_full.box_pose,
+            self.insert_item_full.box_loc,
+            self.insert_item_full.item,
+        )
 
         # BRING ITEM
         # robot already has item and is at handover pose, hand item over, move arm to home pose
         self.bring_item_handover = Method("bring_item_handover", item=self.get_type(Item))
-        bring_item_handover_item = self.bring_item_handover.parameter("item")
-        self.bring_item_handover.set_task(self.bring_item, bring_item_handover_item)
-        self.bring_item_handover.add_precondition(self.robot_has(bring_item_handover_item))
+        self.bring_item_handover.set_task(self.bring_item, self.bring_item_handover.item)
+        self.bring_item_handover.add_precondition(self.robot_has(self.bring_item_handover.item))
         self.bring_item_handover.add_precondition(self.robot_at(self.base_handover_pose))
         s1 = self.bring_item_handover.add_subtask(
-            self.handover_item, self.robot, self.base_handover_pose, bring_item_handover_item
+            self.handover_item, self.robot, self.base_handover_pose, self.bring_item_handover.item
         )
         s2 = self.bring_item_handover.add_subtask(self.adapt_arm, self.arm_pose_home)
         self.bring_item_handover.set_ordered(s1, s2)
 
         # robot already has item, move to handover pose, hand item over, move arm to home pose
         self.bring_item_drive = Method("bring_item_drive", item=self.get_type(Item))
-        bring_item_drive_item = self.bring_item_drive.parameter("item")
-        self.bring_item_drive.set_task(self.bring_item, bring_item_drive_item)
-        self.bring_item_drive.add_precondition(self.robot_has(bring_item_drive_item))
+        self.bring_item_drive.set_task(self.bring_item, self.bring_item_drive.item)
+        self.bring_item_drive.add_precondition(self.robot_has(self.bring_item_drive.item))
         s1 = self.bring_item_drive.add_subtask(self.drive, self.base_handover_pose)
         s2 = self.bring_item_drive.add_subtask(
-            self.handover_item, self.robot, self.base_handover_pose, bring_item_drive_item
+            self.handover_item, self.robot, self.base_handover_pose, self.bring_item_drive.item
         )
         s3 = self.bring_item_drive.add_subtask(self.adapt_arm, self.arm_pose_home)
         self.bring_item_drive.set_ordered(s1, s2, s3)
 
         # go to item location, pick up item, go to handover pose, hand item over, move arm to home pose
         self.bring_item_full = Method("bring_item_full", item=self.get_type(Item))
-        bring_item_full_item = self.bring_item_full.parameter("item")
-        self.bring_item_full.set_task(self.bring_item, bring_item_full_item)
-        s1 = self.bring_item_full.add_subtask(self.get_item, bring_item_full_item)
+        self.bring_item_full.set_task(self.bring_item, self.bring_item_full.item)
+        s1 = self.bring_item_full.add_subtask(self.get_item, self.bring_item_full.item)
         s2 = self.bring_item_full.add_subtask(self.drive, self.base_handover_pose)
         s3 = self.bring_item_full.add_subtask(
-            self.handover_item, self.robot, self.base_handover_pose, bring_item_full_item
+            self.handover_item, self.robot, self.base_handover_pose, self.bring_item_full.item
         )
         s4 = self.bring_item_full.add_subtask(self.adapt_arm, self.arm_pose_home)
         self.bring_item_full.set_ordered(s1, s2, s3, s4)
@@ -301,6 +364,7 @@ class HierarchicalDomain(TablesDemoAPIDomain):
                 self.drive_transport,
                 self.adapt_arm_noop,
                 self.adapt_arm_full,
+                self.perceive_noop,
                 self.perceive_move_arm,
                 self.perceive_location,
                 self.perceive_full,
@@ -313,6 +377,10 @@ class HierarchicalDomain(TablesDemoAPIDomain):
                 self.bring_item_handover,
                 self.bring_item_drive,
                 self.bring_item_full,
+                self.insert_item_noop,
+                self.insert_item_drive,
+                self.insert_item_store,
+                self.insert_item_full,
             ),
             tasks=(
                 self.drive,
@@ -322,6 +390,7 @@ class HierarchicalDomain(TablesDemoAPIDomain):
                 self.put_item,
                 self.move_item,
                 self.bring_item,
+                self.insert_item,
             ),
         )
         self.problem.add_quality_metric(MinimizeSequentialPlanLength())

--- a/tables_demo_planning/src/tables_demo_planning/hierarchical_domain.py
+++ b/tables_demo_planning/src/tables_demo_planning/hierarchical_domain.py
@@ -1,0 +1,192 @@
+# Software License Agreement (BSD License)
+#
+#  Copyright (c) 2022, DFKI GmbH
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the following
+#     disclaimer in the documentation and/or other materials provided
+#     with the distribution.
+#   * Neither the name of Willow Garage nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+#  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+#  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+#  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+#  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+#  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+#  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+#  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+#  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# Authors: Marc Vinci, DFKI
+
+"""Addition of hierarchical methods and tasks to the Mobipick domain."""
+
+
+from typing import Iterable, Optional, Union
+from geometry_msgs.msg import Pose
+from unified_planning.model import Fluent, InstantaneousAction, Object, Action
+from unified_planning.model.htn import HierarchicalProblem, Method, Task, Subtask
+from unified_planning.shortcuts import Equals, Not
+from unified_planning.model.metrics import MinimizeSequentialPlanLength
+from tables_demo_planning.mobipick_components import ArmPose, Item
+from tables_demo_planning.tables_demo_api import TablesDemoAPIDomain
+
+
+class HierarchicalDomain(TablesDemoAPIDomain):
+    def __init__(self) -> None:
+        super().__init__()
+
+        # TASKS
+        self.drive = Task("drive", goal_pose=self.get_type(Pose))
+        self.adapt_arm = Task("adapt_arm", to_pose=self.get_type(ArmPose))
+
+        # METHODS
+
+        # DRIVE
+        # robot already at goal pose
+        self.drive_noop = Method("drive_noop", goal_pose=self.get_type(Pose))
+        drive_noop_goal_pose = self.drive_noop.parameter("goal_pose")
+        self.drive_noop.set_task(self.drive, drive_noop_goal_pose)
+        self.drive_noop.add_precondition(self.robot_at(drive_noop_goal_pose))
+
+        # arm not holding anything, move arm to home pose and move base to goal location
+        self.drive_homeposture = Method(
+            "drive_homeposture", start_pose=self.get_type(Pose), goal_pose=self.get_type(Pose)
+        )
+        drive_homeposture_start_pose = self.drive_homeposture.parameter("start_pose")
+        drive_homeposture_goal_pose = self.drive_homeposture.parameter("goal_pose")
+        self.drive_homeposture.set_task(self.drive, drive_homeposture_goal_pose)
+        self.drive_homeposture.add_precondition(self.robot_at(drive_homeposture_start_pose))
+        self.drive_homeposture.add_precondition(self.robot_has(self.nothing))
+        s1 = self.drive_homeposture.add_subtask(self.adapt_arm, self.arm_pose_home)
+        s2 = self.drive_homeposture.add_subtask(
+            self.move_base, self.robot, drive_homeposture_start_pose, drive_homeposture_goal_pose
+        )
+        self.drive_homeposture.set_ordered(s1, s2)
+
+        # arm holding an item, move arm to transport pose and move base to goal location
+        self.drive_transport = Method(
+            "drive_transport", item=self.get_type(Item), start_pose=self.get_type(Pose), goal_pose=self.get_type(Pose)
+        )
+        drive_transport_start_pose = self.drive_transport.parameter("start_pose")
+        drive_transport_goal_pose = self.drive_transport.parameter("goal_pose")
+        drive_transport_item = self.drive_transport.parameter("item")
+        self.drive_transport.set_task(self.drive, drive_transport_goal_pose)
+        self.drive_transport.add_precondition(self.robot_at(drive_transport_start_pose))
+        self.drive_transport.add_precondition(self.robot_has(drive_transport_item))
+        s1 = self.drive_transport.add_subtask(self.adapt_arm, self.arm_pose_transport)
+        s2 = self.drive_transport.add_subtask(
+            self.move_base_with_item,
+            self.robot,
+            drive_transport_item,
+            drive_transport_start_pose,
+            drive_transport_goal_pose,
+        )
+        self.drive_transport.set_ordered(s1, s2)
+
+        # ADAPT ARM
+        # arm already in goal arm pose
+        self.adapt_arm_noop = Method("adapt_arm_noop", to_pose=self.get_type(ArmPose))
+        adapt_arm_noop_to = self.adapt_arm_noop.parameter("to_pose")
+        self.adapt_arm_noop.set_task(self.adapt_arm, adapt_arm_noop_to)
+        self.adapt_arm_noop.add_precondition(self.robot_arm_at(adapt_arm_noop_to))
+
+        # move arm to goal arm pose
+        self.adapt_arm_op = Method("adapt_arm_op", from_pose=self.get_type(ArmPose), to_pose=self.get_type(ArmPose))
+        adapt_arm_op_from = self.adapt_arm_op.parameter("from_pose")
+        adapt_arm_op_to = self.adapt_arm_op.parameter("to_pose")
+        self.adapt_arm_op.set_task(self.adapt_arm, adapt_arm_op_to)
+        self.adapt_arm_op.add_precondition(self.robot_arm_at(adapt_arm_op_from))
+        self.adapt_arm_op.add_precondition(Not(Equals(adapt_arm_op_from, adapt_arm_op_to)))
+        self.adapt_arm_op.add_subtask(self.move_arm, self.robot, adapt_arm_op_from, adapt_arm_op_to)
+
+        self.problem = self.define_mobipick_problem(
+            fluents=(
+                self.robot_at,
+                self.robot_arm_at,
+                self.robot_has,
+                self.believe_item_at,
+                self.pose_at,
+                self.item_offered,
+                self.searched_at,
+            ),
+            actions=(
+                self.move_base,
+                self.move_base_with_item,
+                self.move_arm,
+                self.pick_item,
+                self.place_item,
+                self.store_item,
+                self.handover_item,
+                self.search_tool,
+                self.search_box,
+                self.search_at,
+            ),
+            methods=(
+                self.drive_noop,
+                self.drive_homeposture,
+                self.drive_transport,
+                self.adapt_arm_noop,
+                self.adapt_arm_op,
+            ),
+            tasks=(
+                self.drive,
+                self.adapt_arm,
+            ),
+        )
+        self.problem.add_quality_metric(MinimizeSequentialPlanLength())
+
+    def define_mobipick_problem(
+        self,
+        fluents: Optional[Iterable[Fluent]] = None,
+        actions: Optional[Iterable[InstantaneousAction]] = None,
+        tasks: Optional[Iterable[Task]] = None,
+        methods: Optional[Iterable[Method]] = None,
+        poses: Optional[Iterable[Object]] = None,
+        items: Optional[Iterable[Object]] = None,
+        locations: Optional[Iterable[Object]] = None,
+    ) -> HierarchicalProblem:
+        """Define hierarchical UP problem by its (potential subsets of) fluents, actions, tasks, methods and objects."""
+        problem = HierarchicalProblem()
+        problem.add_fluents(self._fluents.values() if fluents is None else fluents)
+        problem.add_actions(self._actions.values() if actions is None else actions)
+        objects = set(
+            [self.robot, self.unknown_pose, self.nothing]
+            + (self.poses if poses is None else list(poses))
+            + self.arm_poses
+            + (self.items if items is None else list(items))
+            + (self.locations if locations is None else list(locations))
+        )
+        problem.add_objects(self._objects.values() if objects is None else objects)
+        if tasks is not None:
+            for task in tasks:
+                problem.add_task(task)
+        else:
+            for task in self.tasks:
+                problem.add_task(task)
+        if methods is not None:
+            for method in methods:
+                problem.add_method(method)
+        else:
+            for method in self.methods:
+                problem.add_method(method)
+
+        return problem
+
+    def set_task(self, task: Union[Task, Subtask, Action]) -> None:
+        """Set the task to be executed."""
+        self.problem.task_network.add_subtask(task)

--- a/tables_demo_planning/src/tables_demo_planning/tables_demo.py
+++ b/tables_demo_planning/src/tables_demo_planning/tables_demo.py
@@ -178,7 +178,7 @@ class TablesDemoEnv(EnvironmentRepresentation[R]):
 
 
 class TablesDemoDomain(Domain[E]):
-    DEMO_ITEMS = (Item.box, Item.multimeter, Item.power_drill)
+    DEMO_ITEMS = (Item.box, Item.multimeter)
     TABLE_LOCATIONS = (Location.table_1, Location.table_2, Location.table_3)
     RETRIES_BEFORE_ABORTION = 2
 

--- a/tables_demo_planning/src/tables_demo_planning/tables_demo.py
+++ b/tables_demo_planning/src/tables_demo_planning/tables_demo.py
@@ -96,13 +96,14 @@ class TablesDemoRobot(Robot, ABC, Generic[E]):
 
     def search_at(self, pose: Pose, location: Location) -> bool:
         """At pose, search for item_search at location."""
-        self.env.search_location = location
         item_locations = self.perceive(location)
-        item = self.env.item_search
-        assert item
-        if item in item_locations.keys():
-            print(f"Search for {item.name} SUCCESSFUL.")
-            self.env.item_search = None
+        if self.env.item_search is not None:
+            self.env.search_location = location
+            item = self.env.item_search
+            assert item
+            if item in item_locations.keys():
+                print(f"Search for {item.name} SUCCESSFUL.")
+                self.env.item_search = None
         return True
 
     def check_reset_search(self) -> None:
@@ -177,7 +178,7 @@ class TablesDemoEnv(EnvironmentRepresentation[R]):
 
 
 class TablesDemoDomain(Domain[E]):
-    DEMO_ITEMS = (Item.box, Item.multimeter)
+    DEMO_ITEMS = (Item.box, Item.multimeter, Item.power_drill)
     TABLE_LOCATIONS = (Location.table_1, Location.table_2, Location.table_3)
     RETRIES_BEFORE_ABORTION = 2
 


### PR DESCRIPTION
- Added HierarchicalDomain inheriting from TablesDemoAPIDomain
- Modeled tasks and methods to execute the tables demo using hierarchical planning
- Overwritten and adapted run() function to run the tables demo using hierarchical planning and a hierarchical subproblem for the search of items.
- Added ROS node that uses the hierarchical domain to solve the tables demo
- Changed search_at action to only set search related variables during an actual search to be able to reuse the search_at action as a simple perceive action

**Problem:**
After adding multiple planning methods to enable replanning for the tables demo, the planning time increased significantly to around ~17 seconds. Without these methods it only takes ~0.6 seconds. These methods are necessary for the tables demo to continue if something goes wrong. Without them the planner does not know which actions to skip based on the current state of the environment. They can be seen here: https://github.com/DFKI-NI/mobipick_labs/blob/1b6be5e70ac61ffb66d7c8b940f0cbcca11d0ae9/tables_demo_planning/src/tables_demo_planning/hierarchical_domain.py#L364-L548