### PR TITLE
Install Unified Planning Embedded Systems Bridge via pip.

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -16,7 +16,7 @@ vcs pull
 mobipick/install-deps.sh
 
 # Install Unified Planning library and its planners.
-pip3 install 'unified-planning[tamer,fast-downward]==0.5.0.304.dev1'
+pip3 install 'unified-planning[tamer,fast-downward]==0.5.0.438.dev1'
 
 # Install Unified Planning Embedded Systems Bridge
 pip install up-esb==0.0.136

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -17,4 +17,6 @@ mobipick/install-deps.sh
 
 # Install Unified Planning library and its planners.
 pip3 install 'unified-planning[tamer,fast-downward]==0.5.0.304.dev1'
-pip3 install embedded-systems-bridge/
+
+# Install Unified Planning Embedded Systems Bridge
+pip install up-esb==0.0.136

--- a/my.repos
+++ b/my.repos
@@ -35,6 +35,3 @@ repositories:
     type: git
     url: https://github.com/DFKI-NI/symbolic_fact_generation.git
     version: main
-  embedded-systems-bridge:
-    type: git
-    url: https://github.com/aiplan4eu/embedded-systems-bridge.git


### PR DESCRIPTION
Summary:
- Install `up-esb` via pip 
- Bump `up` version to match the one required by the `up-esb`
- Tested with Gazebo simulation :heavy_check_mark: 

FYI, each merged PR in `up-esb` will automatically release a new version, so it is quite fine-grained and we can update easily as needed. 

Closes #36 