### PR TITLE
Update grasplan branch to noetic

### DIFF
--- a/my.repos
+++ b/my.repos
@@ -10,7 +10,7 @@ repositories:
   grasplan:
     type: git
     url: https://github.com/aprilprojecteu/grasplan.git
-    version: tables-demo
+    version: noetic
   mobipick:
     type: git
     url: https://github.com/DFKI-NI/mobipick.git


### PR DESCRIPTION
I merged the changes in the `tables-demo` branch of grasplan into the (main) `noetic` branch with https://github.com/aprilprojecteu/grasplan/pull/1.