### PR TITLE
Clean up item_locations interface where only the items are required

### DIFF
--- a/tables_demo_planning/nodes/hierarchical_demo_node.py
+++ b/tables_demo_planning/nodes/hierarchical_demo_node.py
@@ -44,15 +44,15 @@ Development in progress.
 import sys
 import rospy
 import unified_planning
-from typing import Optional, Dict
+from typing import Iterable, Optional
 from tables_demo_planning.components import Item, Location
 from tables_demo_planning.hierarchical_domain import HierarchicalDomain
 from tables_demo_planning.subplan_visualization import SubPlanVisualization
 
 
 class HierarchicalDemoOrchestrator:
-    def __init__(self, item_locations: Dict[Item, Location]) -> None:
-        self._domain = HierarchicalDomain(item_locations)
+    def __init__(self, api_items: Iterable[Item]) -> None:
+        self._domain = HierarchicalDomain(api_items)
         self.visualization: Optional[SubPlanVisualization] = None
         self.espeak_pub: Optional[rospy.Publisher] = None
         self._trigger_replanning = False  # Temporary solution until it is provided by dispatcher
@@ -82,15 +82,15 @@ if __name__ == '__main__':
             else:
                 rospy.logwarn(f"Unknown parameter '{parameter}', using default table.")
 
-        item_locations = {
-            Item.get("multimeter_1"): Location.get("table_3"),
-            Item.get("klt_1"): Location.get("table_2"),
-            Item.get("klt_2"): Location.get("table_1"),
-            Item.get("klt_3"): Location.get("table_3"),
-        }
+        demo_items = [
+            Item.get("multimeter_1"),
+            Item.get("klt_1"),
+            Item.get("klt_2"),
+            Item.get("klt_3"),
+        ]
 
         target_item = Item.get("multimeter_1")
         target_box = Item.get("klt_1")
-        HierarchicalDemoOrchestrator(item_locations).generate_and_execute_plan(target_item, target_box, target_location)
+        HierarchicalDemoOrchestrator(demo_items).generate_and_execute_plan(target_item, target_box, target_location)
     except rospy.ROSInterruptException:
         pass

--- a/tables_demo_planning/nodes/pick_n_place_demo_node.py
+++ b/tables_demo_planning/nodes/pick_n_place_demo_node.py
@@ -41,7 +41,7 @@
 import rospy
 from geometry_msgs.msg import Pose
 import unified_planning
-from tables_demo_planning.components import Item, Location
+from tables_demo_planning.components import Item
 from tables_demo_planning.tables_demo_api import TablesDemoAPI
 
 
@@ -49,11 +49,11 @@ def run_demo():
     """Run the handover demo."""
 
     # Define environment values.
-    item_locations = {
-        Item.get("power_drill_with_grip_1"): Location.get("table_2"),
-    }
+    demo_items = [
+        Item.get("power_drill_with_grip_1"),
+    ]
 
-    api = TablesDemoAPI(item_locations)
+    api = TablesDemoAPI(demo_items)
     # Define handover goal.
     api.problem.add_goal(api.domain.robot_at(api.domain.robot, api.domain.get(Pose, "base_home_pose")))
     api.problem.add_goal(api.domain.robot_has(api.domain.robot, api.domain.nothing))

--- a/tables_demo_planning/nodes/tables_demo_node.py
+++ b/tables_demo_planning/nodes/tables_demo_node.py
@@ -49,15 +49,15 @@ if __name__ == '__main__':
     unified_planning.shortcuts.get_environment().credits_stream = None
 
     # Define environment values.
-    item_locations = {
-        Item.get("multimeter_1"): Location.get("table_3"),
-        Item.get("klt_1"): Location.get("table_2"),
-        Item.get("klt_2"): Location.get("table_1"),
-        Item.get("klt_3"): Location.get("table_3"),
-    }
+    demo_items = [
+        Item.get("multimeter_1"),
+        Item.get("klt_1"),
+        Item.get("klt_2"),
+        Item.get("klt_3"),
+    ]
 
     try:
-        api = TablesDemoAPI(item_locations)
+        api = TablesDemoAPI(demo_items)
         # Define goal.
         goal_strs = sys.argv[1:]
         if goal_strs:
@@ -65,7 +65,7 @@ if __name__ == '__main__':
             api.run()
         else:  # Standard tables Demo goal
             target_location = Location.get("table_2")
-            api.domain.set_goals(api.problem, list(item_locations.keys()), target_location)
+            api.domain.set_goals(api.problem, demo_items, target_location)
             print(f"Scenario: Mobipick shall bring a KLT with a multimeter inside to {target_location.name}.")
             api.run(target_location)
     except rospy.ROSInterruptException:

--- a/tables_demo_planning/src/tables_demo_planning/hierarchical_domain.py
+++ b/tables_demo_planning/src/tables_demo_planning/hierarchical_domain.py
@@ -51,9 +51,8 @@ from tables_demo_planning.tables_demo_api import TablesDemoAPI
 
 
 class HierarchicalDomain:
-    def __init__(self, item_locations: Dict[Item, Location]) -> None:
-        self.item_locations = item_locations
-        self.tables_demo_api = TablesDemoAPI(item_locations)
+    def __init__(self, api_items: Iterable[Item]) -> None:
+        self.tables_demo_api = TablesDemoAPI(api_items)
         # Aliases for domain and env variable
         self.domain = self.tables_demo_api.domain
         self.env = self.tables_demo_api.env

--- a/tables_demo_planning/src/tables_demo_planning/tables_demo.py
+++ b/tables_demo_planning/src/tables_demo_planning/tables_demo.py
@@ -39,7 +39,7 @@ The Tables Demo domain and environment specify concrete instances of the scenari
 """
 
 
-from typing import Callable, Dict, List, Optional, Sequence, Set, Tuple
+from typing import Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple
 from collections import defaultdict
 import re
 from geometry_msgs.msg import Pose
@@ -254,8 +254,8 @@ class TablesDemoDomain(Domain):
 
 
 class EnvironmentRepresentation:
-    def __init__(self, item_locations: Dict[Item, Location]) -> None:
-        self.actual_item_locations = item_locations
+    def __init__(self, api_items: Iterable[Item]) -> None:
+        self.api_items = api_items
         self.table_locations = [location for name, location in Location.instances.items() if name.startswith("table_")]
         self.robot_home_poses: Dict[Robot, Pose] = {}
         self.robot_poses: Dict[Robot, Pose] = {}
@@ -326,7 +326,7 @@ class EnvironmentRepresentation:
     def print_believed_item_locations(self) -> None:
         """Print at which locations the items are believed to be."""
         print("The believed item locations are:")
-        for item in self.actual_item_locations.keys():
+        for item in self.api_items:
             print(f"- {item.name}:", self.believed_item_locations[item].name)
 
     def move_base(self, robot: Robot, _: Pose, pose: Pose) -> bool:

--- a/tables_demo_planning/src/tables_demo_planning/tables_demo_api.py
+++ b/tables_demo_planning/src/tables_demo_planning/tables_demo_api.py
@@ -1,7 +1,7 @@
 import rospy
 import rosparam
 
-from typing import Dict, List, Set, Sequence, Union, Optional
+from typing import Dict, Iterable, List, Set, Sequence, Union, Optional
 from collections import defaultdict
 from geometry_msgs.msg import Pose, Point
 from unified_planning.plans import ActionInstance
@@ -18,7 +18,7 @@ from robot_api import TuplePose, is_instance
 class TablesDemoAPI:
     RETRIES_BEFORE_ABORTION = 2
 
-    def __init__(self, item_locations: Dict[Item, Location]) -> None:
+    def __init__(self, api_items: Iterable[Item]) -> None:
         self.mobipick = Robot("mobipick")
         self.mobipick_api = mobipick_api_robot("mobipick", True, True)
         self.domain = TablesDemoDomain(self.mobipick)
@@ -42,12 +42,12 @@ class TablesDemoAPI:
         self.api_poses["klt_search_pose"] = Pose(position=Point(x=-5.0))
         self.api_pose_names = {id(pose): name for name, pose in self.api_poses.items()}
         self.poses = self.domain.create_objects(self.api_poses)
-        self.items = self.domain.create_objects({item.name: item for item in item_locations.keys()})
+        self.items = self.domain.create_objects({item.name: item for item in api_items})
         self.tables = [self.domain.get(Location, name) for name in ("table_1", "table_2", "table_3")]
-        self.env = EnvironmentRepresentation(item_locations)
+        self.env = EnvironmentRepresentation(api_items)
         self.env.perceive = lambda _, location: self.perceive(_, location)
         self.env.initialize_robot_states(self.domain.api_robot, self.api_poses["base_home_pose"])
-        self.demo_items = list(item_locations.keys())
+        self.demo_items = list(api_items)
 
         self.domain.set_fluent_functions(
             [


### PR DESCRIPTION
Another small refactoring pull request which aims at removing actual item locations from the interfaces of real demos where this information is neither given nor needed. Concept:

- Retain `item_locations` only for simulation.
- At interfaces where the relevant items must be provided, expect `api_items: Iterable[Item]`.
- When creating demos, only specify `demo_items: List[Item]` at script level. Their location information must come from other sources, e.g., symbolic fact generation.

If you encounter errors due to missing UP locations, please make sure to create them during environment setup. Previously, the `Location.get()` commands did it implicitly but as of now, https://github.com/DFKI-NI/mobipick_labs/blob/noetic/tables_demo_planning/src/tables_demo_planning/tables_demo_api.py#L46 is probably doing it for the three tables explicitly listed there.