### PR TITLE
Added ROS action server to send hierarchical tasks to plan and execute

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,46 @@ If no `simulate_user_interaction` command is given within a timeout of 30
 seconds, plan execution will fail (as expected, since the handover was
 unsuccessful).
 
+Hierarchical planning using ROS task server
+------------------
+
+Used to send hierarchical tasks directly to the planner and executor.
+
+On the real robot:
+
+```bash
+roslaunch mobipick_bringup mobipick_bringup_both.launch
+roslaunch pbr_dope dope.launch
+rosrun tables_demo_planning task_server_node.py
+```
+
+For Gazebo:
+
+```bash
+roslaunch tables_demo_bringup demo_sim.launch
+rosrun tables_demo_planning task_server_node.py
+```
+
+Now tasks can be sent to the robot using the ROS client provided:
+
+```bash
+rosrun tables_demo_planning task_server_client.py task_name parameter_1 ... parameter_n
+```
+
+Depending on the chosen task, different parameters have to be sent to the server.
+Available tasks and their parameters can be seen
+[here](https://github.com/DFKI-NI/mobipick_labs/blob/4d8e48adc9d2b78682e91e4ad9c091baa03fc4ec/tables_demo_planning/src/tables_demo_planning/hierarchical_domain.py#L89-L98).
+
+Example task to move the multimeter_1 from its current location to table_2:
+
+```bash
+rosrun tables_demo_planning task_server_client.py move_item mobipick multimeter_1 table_2
+```
+
+Additionally it is possible to send tasks to the task server using the provided
+[ROS action message](https://github.com/DFKI-NI/mobipick_labs/blob/aaf5639ced33866c17eb036fcd22b27cd72cff21/tables_demo_planning/action/PlanAndExecuteTasks.action).
+The default topic to send ROS actions to is `/mobipick/task_planning`.
+
 
 Plan visualization
 ------------------

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ pre-commit install
 Citation
 --------
 
-If you use this work in your research, consider citing our 
+If you use this work in your research, consider citing our
 [PlanRob 2023 paper](https://icaps23.icaps-conference.org/program/workshops/planrob/PlanRob-23_paper_9.pdf):
 
 ```plain

--- a/tables_demo_bringup/config/initial_items.yaml
+++ b/tables_demo_bringup/config/initial_items.yaml
@@ -1,0 +1,10 @@
+initial_item_locations: {
+  "multimeter_1": "table_3",
+  "relay_1": "table_3",
+  "screwdriver_1": "table_3",
+  "power_drill_with_grip_1": "table_2",
+  "hot_glue_gun_1": "table_3",
+  "klt_1": "table_2",
+  "klt_2": "table_1",
+  "klt_3": "table_3",
+}

--- a/tables_demo_bringup/launch/bringup.launch
+++ b/tables_demo_bringup/launch/bringup.launch
@@ -61,4 +61,6 @@
 
   <!-- config for tables_demo_planning -->
   <rosparam command="load" file="$(find mobipick_pick_n_place)/config/$(arg world_config)_demo.yaml" ns="mobipick/tables_demo_planning" />
+  <!-- config for items used in the demos-->
+  <rosparam command="load" file="$(find tables_demo_bringup)/config/initial_items.yaml" ns="mobipick/tables_demo_planning" />
 </launch>

--- a/tables_demo_planning/CMakeLists.txt
+++ b/tables_demo_planning/CMakeLists.txt
@@ -33,5 +33,6 @@ catkin_install_python(PROGRAMS
   nodes/uplexmo_tables_demo_node.py
   nodes/hierarchical_demo_node.py
   nodes/task_server_node.py
+  nodes/task_server_client.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/tables_demo_planning/CMakeLists.txt
+++ b/tables_demo_planning/CMakeLists.txt
@@ -1,14 +1,26 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(tables_demo_planning)
 
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED message_generation actionlib_msgs)
 
-catkin_python_setup()
+add_action_files(
+  DIRECTORY action
+  FILES
+  PlanAndExecuteTask.action
+)
 
 ###################################
 ## catkin specific configuration ##
 ###################################
-catkin_package()
+catkin_python_setup()
+
+generate_messages(
+  DEPENDENCIES actionlib_msgs
+)
+
+catkin_package(
+  CATKIN_DEPENDS message_runtime actionlib_msgs
+)
 
 #############
 ## Install ##
@@ -20,5 +32,6 @@ catkin_install_python(PROGRAMS
   nodes/uplexmo_pick_n_place_demo_node.py
   nodes/uplexmo_tables_demo_node.py
   nodes/hierarchical_demo_node.py
+  nodes/task_server_node.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/tables_demo_planning/CMakeLists.txt
+++ b/tables_demo_planning/CMakeLists.txt
@@ -3,10 +3,16 @@ project(tables_demo_planning)
 
 find_package(catkin REQUIRED message_generation actionlib_msgs)
 
+add_message_files(
+  FILES
+  Task.msg
+)
+
+
 add_action_files(
   DIRECTORY action
   FILES
-  PlanAndExecuteTask.action
+  PlanAndExecuteTasks.action
 )
 
 ###################################

--- a/tables_demo_planning/action/PlanAndExecuteTask.action
+++ b/tables_demo_planning/action/PlanAndExecuteTask.action
@@ -1,0 +1,6 @@
+string task
+string[] parameters
+---
+bool success
+string message
+---

--- a/tables_demo_planning/action/PlanAndExecuteTask.action
+++ b/tables_demo_planning/action/PlanAndExecuteTask.action
@@ -1,6 +1,0 @@
-string task
-string[] parameters
----
-bool success
-string message
----

--- a/tables_demo_planning/action/PlanAndExecuteTasks.action
+++ b/tables_demo_planning/action/PlanAndExecuteTasks.action
@@ -1,0 +1,7 @@
+tables_demo_planning/Task[] tasks
+---
+bool[] success
+string[] message
+---
+bool success
+string message

--- a/tables_demo_planning/msg/Task.msg
+++ b/tables_demo_planning/msg/Task.msg
@@ -1,0 +1,2 @@
+string task
+string[] parameters

--- a/tables_demo_planning/nodes/hierarchical_demo_node.py
+++ b/tables_demo_planning/nodes/hierarchical_demo_node.py
@@ -44,15 +44,15 @@ Development in progress.
 import sys
 import rospy
 import unified_planning
-from typing import Iterable, Optional
+from typing import Optional
 from tables_demo_planning.components import Item, Location
 from tables_demo_planning.hierarchical_domain import HierarchicalDomain
 from tables_demo_planning.subplan_visualization import SubPlanVisualization
 
 
 class HierarchicalDemoOrchestrator:
-    def __init__(self, api_items: Iterable[Item]) -> None:
-        self._domain = HierarchicalDomain(api_items)
+    def __init__(self) -> None:
+        self._domain = HierarchicalDomain()
         self.visualization: Optional[SubPlanVisualization] = None
         self.espeak_pub: Optional[rospy.Publisher] = None
         self._trigger_replanning = False  # Temporary solution until it is provided by dispatcher
@@ -82,15 +82,8 @@ if __name__ == '__main__':
             else:
                 rospy.logwarn(f"Unknown parameter '{parameter}', using default table.")
 
-        demo_items = [
-            Item.get("multimeter_1"),
-            Item.get("klt_1"),
-            Item.get("klt_2"),
-            Item.get("klt_3"),
-        ]
-
         target_item = Item.get("multimeter_1")
         target_box = Item.get("klt_1")
-        HierarchicalDemoOrchestrator(demo_items).generate_and_execute_plan(target_item, target_box, target_location)
+        HierarchicalDemoOrchestrator().generate_and_execute_plan(target_item, target_box, target_location)
     except rospy.ROSInterruptException:
         pass

--- a/tables_demo_planning/nodes/pick_n_place_demo_node.py
+++ b/tables_demo_planning/nodes/pick_n_place_demo_node.py
@@ -48,12 +48,7 @@ from tables_demo_planning.tables_demo_api import TablesDemoAPI
 def run_demo():
     """Run the handover demo."""
 
-    # Define environment values.
-    demo_items = [
-        Item.get("power_drill_with_grip_1"),
-    ]
-
-    api = TablesDemoAPI(demo_items)
+    api = TablesDemoAPI()
     # Define handover goal.
     api.problem.add_goal(api.domain.robot_at(api.domain.robot, api.domain.get(Pose, "base_home_pose")))
     api.problem.add_goal(api.domain.robot_has(api.domain.robot, api.domain.nothing))

--- a/tables_demo_planning/nodes/tables_demo_node.py
+++ b/tables_demo_planning/nodes/tables_demo_node.py
@@ -41,24 +41,15 @@
 import sys
 import rospy
 import unified_planning
-from tables_demo_planning.components import Item, Location
+from tables_demo_planning.components import Location
 from tables_demo_planning.tables_demo_api import TablesDemoAPI
 
 
 if __name__ == '__main__':
     unified_planning.shortcuts.get_environment().credits_stream = None
 
-    # Define environment values.
-    demo_items = [
-        Item.get("multimeter_1"),
-        Item.get("power_drill_with_grip_1"),
-        Item.get("klt_1"),
-        Item.get("klt_2"),
-        Item.get("klt_3"),
-    ]
-
     try:
-        api = TablesDemoAPI(demo_items)
+        api = TablesDemoAPI()
         # Define goal.
         goal_strs = sys.argv[1:]
         if goal_strs:
@@ -66,7 +57,7 @@ if __name__ == '__main__':
             api.run()
         else:  # Standard tables Demo goal
             target_location = Location.get("table_2")
-            api.domain.set_goals(api.problem, demo_items, target_location)
+            api.domain.set_goals(api.problem, api.demo_items, target_location)
             print(f"Scenario: Mobipick shall bring a KLT with a multimeter inside to {target_location.name}.")
             api.run(target_location)
     except rospy.ROSInterruptException:

--- a/tables_demo_planning/nodes/task_server_client.py
+++ b/tables_demo_planning/nodes/task_server_client.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+# Software License Agreement (BSD License)
+#
+#  Copyright (c) 2022, DFKI GmbH
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the following
+#     disclaimer in the documentation and/or other materials provided
+#     with the distribution.
+#   * Neither the name of Willow Garage nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+#  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+#  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+#  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+#  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+#  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+#  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+#  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+#  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# Authors: Sebastian Stock, Marc Vinci
+
+
+import sys
+import rospy
+import actionlib
+from tables_demo_planning.msg import (
+    PlanAndExecuteTaskAction,
+    PlanAndExecuteTaskGoal,
+)
+
+
+def main():
+    rospy.init_node("task_server_client_node")
+    task_server_name = rospy.get_param(
+        "~task_server_name",
+        default="/mobipick/task_planning",
+    )
+    client = actionlib.SimpleActionClient(task_server_name, PlanAndExecuteTaskAction)
+    client.wait_for_server()
+
+    goal = PlanAndExecuteTaskGoal()
+    if len(sys.argv) >= 2:
+        goal.task = sys.argv[1]
+        goal.parameters = sys.argv[2:]
+        client.send_goal_and_wait()
+        res = client.get_result()
+        if res.success:
+            rospy.loginfo("Task execution succeeded!")
+        else:
+            rospy.loginfo("Task execution failed: %s" % res.message)
+
+    else:
+        rospy.logerr("Missing arguments")
+        rospy.logerr("Usage: task_server_client task_name [arg1] [arg2] ... [arg_n]")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except rospy.ROSInterruptException:
+        pass

--- a/tables_demo_planning/nodes/task_server_client.py
+++ b/tables_demo_planning/nodes/task_server_client.py
@@ -58,7 +58,7 @@ def main():
     if len(sys.argv) >= 2:
         goal.task = sys.argv[1]
         goal.parameters = sys.argv[2:]
-        client.send_goal_and_wait()
+        client.send_goal_and_wait(goal)
         res = client.get_result()
         if res.success:
             rospy.loginfo("Task execution succeeded!")

--- a/tables_demo_planning/nodes/task_server_client.py
+++ b/tables_demo_planning/nodes/task_server_client.py
@@ -39,10 +39,7 @@
 import sys
 import rospy
 import actionlib
-from tables_demo_planning.msg import (
-    PlanAndExecuteTaskAction,
-    PlanAndExecuteTaskGoal,
-)
+from tables_demo_planning.msg import PlanAndExecuteTasksAction, PlanAndExecuteTasksGoal, Task
 
 
 def main():
@@ -51,19 +48,16 @@ def main():
         "~task_server_name",
         default="/mobipick/task_planning",
     )
-    client = actionlib.SimpleActionClient(task_server_name, PlanAndExecuteTaskAction)
+    client = actionlib.SimpleActionClient(task_server_name, PlanAndExecuteTasksAction)
     client.wait_for_server()
 
-    goal = PlanAndExecuteTaskGoal()
+    goal = PlanAndExecuteTasksGoal()
     if len(sys.argv) >= 2:
-        goal.task = sys.argv[1]
-        goal.parameters = sys.argv[2:]
+        goal.tasks.append(Task(task=sys.argv[1], parameters=sys.argv[2:]))
         client.send_goal_and_wait(goal)
         res = client.get_result()
-        if res.success:
-            rospy.loginfo("Task execution succeeded!")
-        else:
-            rospy.loginfo("Task execution failed: %s" % res.message)
+        for msg in res.message:
+            rospy.loginfo(msg)
 
     else:
         rospy.logerr("Missing arguments")

--- a/tables_demo_planning/nodes/task_server_node.py
+++ b/tables_demo_planning/nodes/task_server_node.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+
+import rospy
+import unified_planning
+import actionlib
+from typing import List
+from unified_planning.plans import Plan
+from unified_planning.shortcuts import OneshotPlanner, Problem
+from unified_planning.engines import OptimalityGuarantee
+from up_esb.plexmo import PlanDispatcher
+from tables_demo_planning.msg import (
+    PlanAndExecuteTaskAction,
+    PlanAndExecuteTaskGoal,
+    PlanAndExecuteTaskResult,
+)
+from tables_demo_planning.mobipick_components import Item, Location
+
+
+class TaskServerNode:
+    def __init__(self) -> None:
+        rospy.init_node("task_server_node")
+        task_server_name = rospy.get_param(
+            "~task_server_name",
+            default="/mobipick/task_planning",
+        )
+
+        domain_class = rospy.get_param("~domain_class", default="DemoDayDomain")
+        domain_module = rospy.get_param("~domain_module", default="tables_demo_planning.ai_day_demo")
+
+        try:
+            # Initialize domain by importing python class and calling __init__ without arguments
+            # using the module and class specified in the ros parameters
+            self._domain = getattr(__import__(domain_module, fromlist=[domain_class]), domain_class)()
+        except ImportError as e:
+            print(f"Could not import {domain_module} module for {domain_class} domain: {e}")
+
+        self._dispatcher = PlanDispatcher()
+
+        self._task_server = actionlib.SimpleActionServer(
+            task_server_name,
+            PlanAndExecuteTaskAction,
+            execute_cb=self.generate_and_execute_plan,
+            auto_start=False,
+        )
+        self._task_server.register_preempt_callback(self.preempt_cb)
+        self._task_server.start()
+
+    def preempt_cb(self) -> None:
+        self._domain.problem.clear_goals()
+
+    def solve_problem(self, problem: Problem) -> Plan:
+        # TODO Remove or adapt for new domain
+        """Solve planning problem and return plan."""
+        result = OneshotPlanner(
+            problem_kind=problem.kind,
+            optimality_guarantee=OptimalityGuarantee.SOLVED_OPTIMALLY,
+        ).solve(problem)
+        if result.status and result.status.value > 2:
+            if result.log_messages:
+                rospy.logerr(f"Error during plan generation: {result.log_messages[0].message}")
+            else:
+                rospy.logerr(f"Error during plan generation: {result.status}")
+        rospy.loginfo(f"Result received from '{result.engine_name}' planner.")
+        return result.plan if result.plan else None
+
+    def set_goals(self, task: str, parameters: List[str]) -> None:
+        """Set the goals given by the task message."""
+        # TODO OLD uses goals and fluents from castle demo
+        # Used to map tasks send via ros message to goals for the planner
+        self._domain.problem.clear_goals()
+        if task == "bring_item" and parameters and len(parameters) == 1:
+            self._domain.problem.add_goal(self._domain.item_offered(self._domain.objects[parameters[0]]))
+        elif task == "move_item" and parameters and len(parameters) == 2:
+            self._domain.problem.add_goal(
+                self._domain.believe_item_at(
+                    self._domain.objects[parameters[0]],
+                    self._domain.objects[parameters[1]],
+                )
+            )
+
+    def set_item_locations(self) -> None:
+        # TODO OLD still using items and locations from castle demo
+        # HACK hardcoded initial object locations
+        initial_item_locations = {}
+        initial_item_locations[Item.multimeter] = Location.table_3
+        initial_item_locations[Item.relay] = Location.table_3
+        initial_item_locations[Item.screwdriver] = Location.table_3
+        initial_item_locations[Item.box] = Location.table_2
+        initial_item_locations[Item.power_drill] = Location.table_2
+        # add only items, which are not already set to avoid overriding perceived locations
+        for item in list(initial_item_locations.keys()):
+            if item in self._domain.env.believed_item_locations:
+                del initial_item_locations[item]
+        self._domain.env.believed_item_locations.update(initial_item_locations)
+
+    def generate_plan(self, request) -> Plan:
+        # TODO Remove or change to new domain
+        # generate problem and plan
+        self._domain.set_initial_values(self._domain.problem)
+        self.set_goals(request.task, request.parameters)
+        return self.solve_problem(self._domain.problem)
+
+    def generate_and_execute_plan(self, request: PlanAndExecuteTaskGoal) -> None:
+        # HACK setting initial item locations
+        # self.set_item_locations()
+
+        # TODO replace with function provided by domain to generate a plan
+        # plan = self.generate_plan(request)
+        plan = self._domain.calculate_plan_to_get_all_items(["Item_1", "Item_2"])
+
+        if not plan:
+            print("Could not find a plan. Exiting.")
+            self._task_server.set_aborted(
+                result=PlanAndExecuteTaskResult(success=False, message="Could not find a plan!")
+            )
+            return
+
+        print("> Plan:")
+        print("\n".join(map(str, plan)))
+
+        # TODO Uncomment execution, change as needed for new domain
+
+        # graph = self._domain.get_executable_graph(plan)
+
+        # # execute the plan
+        # print("> Execution:")
+        # dispatcher_result = self._dispatcher.execute_plan(plan, graph)
+        # print(">Dispatcher finished with result " + str(dispatcher_result))
+        dispatcher_result = True
+        if dispatcher_result:
+            self._task_server.set_succeeded(
+                PlanAndExecuteTaskResult(success=True, message="Successfully executed task!")
+            )
+        else:
+            self._task_server.set_aborted(PlanAndExecuteTaskResult(success=False, message="Plan execution failed!"))
+
+
+if __name__ == "__main__":
+    unified_planning.shortcuts.get_environment().credits_stream = None
+    try:
+        TaskServerNode()
+        rospy.spin()
+    except rospy.ROSInterruptException:
+        pass

--- a/tables_demo_planning/nodes/task_server_node.py
+++ b/tables_demo_planning/nodes/task_server_node.py
@@ -119,7 +119,7 @@ class TaskServerNode:
             print("> Execution:")
             for action in actions:
                 if action.action.name == "trigger_replanning":
-                    plan = self.create_plan(request.task, request.parameters)
+                    plan = self._domain.create_plan(request.task, request.parameters)
                     actions = plan.action_plan.actions
                     break
                 executable_action, parameters = self._domain.get_executable_action(action)

--- a/tables_demo_planning/nodes/task_server_node.py
+++ b/tables_demo_planning/nodes/task_server_node.py
@@ -12,7 +12,6 @@ from tables_demo_planning.msg import (
     PlanAndExecuteTasksFeedback,
 )
 from unified_planning.shortcuts import get_environment
-from tables_demo_planning.components import Item, Location
 
 
 class TaskServerNode:
@@ -23,35 +22,17 @@ class TaskServerNode:
             default="/mobipick/task_planning",
         )
 
-        # default values
-        initial_item_locations = {
-            "multimeter_1": "table_3",
-            "relay_1": "table_3",
-            "screwdriver_1": "table_3",
-            "power_drill_with_grip_1": "table_2",
-            "hot_glue_gun_1": "table_3",
-            "klt_1": "table_2",
-            "klt_2": "table_1",
-            "klt_3": "table_3",
-        }
-
-        initial_item_locations_param = rospy.get_param("~initial_item_locations", default=initial_item_locations)
-
-        self.initial_item_locations = {}
-        for item, location in initial_item_locations_param.items():
-            self.initial_item_locations[Item.get(item)] = Location.get(location)
-
         domain_class = rospy.get_param("~domain_class", default="HierarchicalDomain")
         domain_module = rospy.get_param("~domain_module", default="tables_demo_planning.hierarchical_domain")
 
         try:
             # Initialize domain by importing python class and calling __init__ without arguments
             # using the module and class specified in the ros parameters
-            self._domain = getattr(__import__(domain_module, fromlist=[domain_class]), domain_class)(
-                list(self.initial_item_locations.keys())
-            )
+            self._domain = getattr(__import__(domain_module, fromlist=[domain_class]), domain_class)()
         except ImportError as e:
             print(f"Could not import {domain_module} module for {domain_class} domain: {e}")
+
+        self.initial_item_locations = self._domain.tables_demo_api.initial_item_locations
 
         self._dispatcher = PlanDispatcher()
 

--- a/tables_demo_planning/nodes/task_server_node.py
+++ b/tables_demo_planning/nodes/task_server_node.py
@@ -6,9 +6,10 @@ from collections import defaultdict
 from typing import Dict, List
 from up_esb.plexmo import PlanDispatcher
 from tables_demo_planning.msg import (
-    PlanAndExecuteTaskAction,
-    PlanAndExecuteTaskGoal,
-    PlanAndExecuteTaskResult,
+    PlanAndExecuteTasksAction,
+    PlanAndExecuteTasksGoal,
+    PlanAndExecuteTasksResult,
+    PlanAndExecuteTasksFeedback,
 )
 from unified_planning.shortcuts import get_environment
 from tables_demo_planning.components import Item, Location
@@ -47,7 +48,7 @@ class TaskServerNode:
 
         self._task_server = actionlib.SimpleActionServer(
             task_server_name,
-            PlanAndExecuteTaskAction,
+            PlanAndExecuteTasksAction,
             execute_cb=self.generate_and_execute_plan,
             auto_start=False,
         )
@@ -90,70 +91,85 @@ class TaskServerNode:
                 del initial_item_locations[item]
         self._domain.env.believed_item_locations.update(initial_item_locations)
 
-    def generate_and_execute_plan(self, request: PlanAndExecuteTaskGoal) -> None:
+    def generate_and_execute_plan(self, request: PlanAndExecuteTasksGoal) -> None:
         retries_before_abortion = 3
         error_counts: Dict[str, int] = defaultdict(int)
         self.set_item_locations()
-        plan = self._domain.create_plan(request.task, request.parameters)
 
-        if not plan:
-            print("Could not find a plan. Exiting.")
-            self._task_server.set_aborted(
-                result=PlanAndExecuteTaskResult(success=False, message="Could not find a plan!")
-            )
-            return
+        result_msg = PlanAndExecuteTasksResult()
 
-        print("> Plan:")
-        print("\n".join(map(str, plan.action_plan.actions)))
+        for task in request.tasks:
+            plan = self._domain.create_plan(task.task, task.parameters)
 
-        actions = plan.action_plan.actions
+            exec_result = True
+            exec_msg = f"{task.task}{task.parameters} successfully executed!"
 
-        # Loop action execution as long as there are actions.
-        while actions:
-            print("> Execution:")
-            for action in actions:
-                if action.action.name == "trigger_replanning":
-                    plan = self._domain.create_plan(request.task, request.parameters)
-                    actions = plan.action_plan.actions
-                    break
-                executable_action, parameters = self._domain.domain.get_executable_action(action)
-                print(action)
+            if not plan:
+                print("Could not find a plan for task.")
+                result_msg.success.append(False)
+                result_msg.message.append(f"Could not find a plan for task {task.task}{task.parameters}!")
+                continue
 
-                # Execute action.
-                result = executable_action(*parameters)
-                if rospy.is_shutdown():
-                    self._task_server.set_aborted(
-                        PlanAndExecuteTaskResult(success=False, message="Plan execution failed!")
-                    )
-                    return
-                if result is not None:
-                    if not result:
-                        error_counts[self._domain.tables_demo_api.label(action)] += 1
-                        # Note: This will also fail if two different failures occur successively.
-                        if retries_before_abortion <= 0 or any(count >= 3 for count in error_counts.values()):
-                            print("Task could not be completed even after retrying.")
-                            return
+            print("> Plan:")
+            print("\n".join(map(str, plan.action_plan.actions)))
 
-                        retries_before_abortion -= 1
-                        plan = self._domain.create_plan(request.task, request.parameters)
-                        actions = plan.action_plan.actions
+            actions = plan.action_plan.actions
+
+            # Loop action execution as long as there are actions.
+            while actions:
+                print("> Execution:")
+                for action in actions:
+                    executable_action, parameters = self._domain.domain.get_executable_action(action)
+                    print(action)
+
+                    # Execute action.
+                    result = executable_action(*parameters)
+                    if rospy.is_shutdown():
+                        result_msg.success.append(False)
+                        result_msg.message.append(
+                            f"Plan execution failed for task {task.task}{task.parameters}. ROS Node was shut down!"
+                        )
+                        self._task_server.set_aborted(result_msg)
+                        return
+                    if result is not None:
+                        if not result:
+                            error_counts[self._domain.tables_demo_api.label(action)] += 1
+                            # Note: This will also fail if two different failures occur successively.
+                            if retries_before_abortion <= 0 or any(count >= 3 for count in error_counts.values()):
+                                print("Task could not be completed even after retrying.")
+                                result_msg.success.append(False)
+                                result_msg.message.append(
+                                    f"Task {task.task}{task.parameters} could not be completed even after retrying."
+                                )
+                                self._task_server.set_aborted(result_msg)
+                                return
+
+                            retries_before_abortion -= 1
+                            plan = self._domain.create_plan(task.task, task.parameters)
+                            actions = plan.action_plan.actions if plan is not None else None
+                            break
+                    else:
+                        retries_before_abortion = 3
+                        plan = self._domain.create_plan(task.task, task.parameters)
+                        actions = plan.action_plan.actions if plan is not None else None
                         break
                 else:
-                    retries_before_abortion = 3
-                    plan = self._domain.create_plan(request.task, request.parameters)
-                    actions = plan.action_plan.actions
                     break
-            else:
-                self._task_server.set_aborted(PlanAndExecuteTaskResult(success=False, message="Plan execution failed!"))
-                break
-            if actions is None:
-                print("Execution ended because no plan could be found.")
-                self._task_server.set_aborted(PlanAndExecuteTaskResult(success=False, message="Plan execution failed!"))
-                break
+                if actions is None:
+                    exec_result = False
+                    exec_msg = (
+                        f"Plan execution ended because no plan could be found for task {task.task}{task.parameters}!"
+                    )
+                    break
+            self._task_server.publish_feedback(PlanAndExecuteTasksFeedback(success=exec_result, message=exec_msg))
+            result_msg.success.append(exec_result)
+            result_msg.message.append(exec_msg)
 
-        print("Demo complete.")
-
-        self._task_server.set_succeeded(PlanAndExecuteTaskResult(success=True, message="Successfully executed task!"))
+        if not any(result_msg.success):
+            self._task_server.set_aborted(result_msg)
+        else:
+            print("Tasks complete.")
+            self._task_server.set_succeeded(result_msg)
 
 
 if __name__ == "__main__":

--- a/tables_demo_planning/nodes/task_server_node.py
+++ b/tables_demo_planning/nodes/task_server_node.py
@@ -3,17 +3,14 @@
 import rospy
 import unified_planning
 import actionlib
-from typing import List
-from unified_planning.plans import Plan
-from unified_planning.shortcuts import OneshotPlanner, Problem
-from unified_planning.engines import OptimalityGuarantee
+from collections import defaultdict
+from typing import Dict
 from up_esb.plexmo import PlanDispatcher
 from tables_demo_planning.msg import (
     PlanAndExecuteTaskAction,
     PlanAndExecuteTaskGoal,
     PlanAndExecuteTaskResult,
 )
-from tables_demo_planning.mobipick_components import Item, Location
 
 
 class TaskServerNode:
@@ -101,6 +98,8 @@ class TaskServerNode:
         return self.solve_problem(self._domain.problem)
 
     def generate_and_execute_plan(self, request: PlanAndExecuteTaskGoal) -> None:
+        retries_before_abortion = 3
+        error_counts: Dict[str, int] = defaultdict(int)
         plan = self._domain.create_plan(request.task, request.parameters)
 
         if not plan:
@@ -113,19 +112,54 @@ class TaskServerNode:
         print("> Plan:")
         print("\n".join(map(str, plan.action_plan.actions)))
 
-        graph = self._domain.get_executable_graph(plan.action_plan)
+        actions = plan.action_plan.actions
 
-        # execute the plan
-        print("> Execution:")
-        dispatcher_result = self._dispatcher.execute_plan(plan.action_plan, graph)
-        print(">Dispatcher finished with result " + str(dispatcher_result))
-        dispatcher_result = True
-        if dispatcher_result:
-            self._task_server.set_succeeded(
-                PlanAndExecuteTaskResult(success=True, message="Successfully executed task!")
-            )
-        else:
-            self._task_server.set_aborted(PlanAndExecuteTaskResult(success=False, message="Plan execution failed!"))
+        # Loop action execution as long as there are actions.
+        while actions:
+            print("> Execution:")
+            for action in actions:
+                if action.action.name == "trigger_replanning":
+                    plan = self.create_plan(request.task, request.parameters)
+                    actions = plan.action_plan.actions
+                    break
+                executable_action, parameters = self._domain.get_executable_action(action)
+                print(action)
+
+                # Execute action.
+                result = executable_action(*parameters)
+                if rospy.is_shutdown():
+                    self._task_server.set_aborted(
+                        PlanAndExecuteTaskResult(success=False, message="Plan execution failed!")
+                    )
+                    return
+                if result is not None:
+                    if not result:
+                        error_counts[self._domain.label(action)] += 1
+                        # Note: This will also fail if two different failures occur successively.
+                        if retries_before_abortion <= 0 or any(count >= 3 for count in error_counts.values()):
+                            print("Task could not be completed even after retrying.")
+                            return
+
+                        retries_before_abortion -= 1
+                        plan = self._domain.create_plan(request.task, request.parameters)
+                        actions = plan.action_plan.actions
+                        break
+                else:
+                    retries_before_abortion = 3
+                    plan = self._domain.create_plan(request.task, request.parameters)
+                    actions = plan.action_plan.actions
+                    break
+            else:
+                self._task_server.set_aborted(PlanAndExecuteTaskResult(success=False, message="Plan execution failed!"))
+                break
+            if actions is None:
+                print("Execution ended because no plan could be found.")
+                self._task_server.set_aborted(PlanAndExecuteTaskResult(success=False, message="Plan execution failed!"))
+                break
+
+        print("Demo complete.")
+
+        self._task_server.set_succeeded(PlanAndExecuteTaskResult(success=True, message="Successfully executed task!"))
 
 
 if __name__ == "__main__":

--- a/tables_demo_planning/nodes/task_server_node.py
+++ b/tables_demo_planning/nodes/task_server_node.py
@@ -24,8 +24,8 @@ class TaskServerNode:
             default="/mobipick/task_planning",
         )
 
-        domain_class = rospy.get_param("~domain_class", default="DemoDayDomain")
-        domain_module = rospy.get_param("~domain_module", default="tables_demo_planning.ai_day_demo")
+        domain_class = rospy.get_param("~domain_class", default="HierarchicalDomain")
+        domain_module = rospy.get_param("~domain_module", default="tables_demo_planning.hierarchical_domain")
 
         try:
             # Initialize domain by importing python class and calling __init__ without arguments
@@ -101,12 +101,7 @@ class TaskServerNode:
         return self.solve_problem(self._domain.problem)
 
     def generate_and_execute_plan(self, request: PlanAndExecuteTaskGoal) -> None:
-        # HACK setting initial item locations
-        # self.set_item_locations()
-
-        # TODO replace with function provided by domain to generate a plan
-        # plan = self.generate_plan(request)
-        plan = self._domain.calculate_plan_to_get_all_items(["Item_1", "Item_2"])
+        plan = self._domain.create_plan(request.task, request.parameters)
 
         if not plan:
             print("Could not find a plan. Exiting.")
@@ -116,16 +111,14 @@ class TaskServerNode:
             return
 
         print("> Plan:")
-        print("\n".join(map(str, plan)))
+        print("\n".join(map(str, plan.action_plan.actions)))
 
-        # TODO Uncomment execution, change as needed for new domain
+        graph = self._domain.get_executable_graph(plan.action_plan)
 
-        # graph = self._domain.get_executable_graph(plan)
-
-        # # execute the plan
-        # print("> Execution:")
-        # dispatcher_result = self._dispatcher.execute_plan(plan, graph)
-        # print(">Dispatcher finished with result " + str(dispatcher_result))
+        # execute the plan
+        print("> Execution:")
+        dispatcher_result = self._dispatcher.execute_plan(plan.action_plan, graph)
+        print(">Dispatcher finished with result " + str(dispatcher_result))
         dispatcher_result = True
         if dispatcher_result:
             self._task_server.set_succeeded(

--- a/tables_demo_planning/nodes/task_server_node.py
+++ b/tables_demo_planning/nodes/task_server_node.py
@@ -23,16 +23,23 @@ class TaskServerNode:
             default="/mobipick/task_planning",
         )
 
-        demo_items = [
-            Item.get("multimeter_1"),
-            Item.get("relay_1"),
-            Item.get("screwdriver_1"),
-            Item.get("power_drill_with_grip_1"),
-            Item.get("hot_glue_gun_1"),
-            Item.get("klt_1"),
-            Item.get("klt_2"),
-            Item.get("klt_3"),
-        ]
+        # default values
+        initial_item_locations = {
+            "multimeter_1": "table_3",
+            "relay_1": "table_3",
+            "screwdriver_1": "table_3",
+            "power_drill_with_grip_1": "table_2",
+            "hot_glue_gun_1": "table_3",
+            "klt_1": "table_2",
+            "klt_2": "table_1",
+            "klt_3": "table_3",
+        }
+
+        initial_item_locations_param = rospy.get_param("~initial_item_locations", default=initial_item_locations)
+
+        self.initial_item_locations = {}
+        for item, location in initial_item_locations_param.items():
+            self.initial_item_locations[Item.get(item)] = Location.get(location)
 
         domain_class = rospy.get_param("~domain_class", default="HierarchicalDomain")
         domain_module = rospy.get_param("~domain_module", default="tables_demo_planning.hierarchical_domain")
@@ -40,7 +47,9 @@ class TaskServerNode:
         try:
             # Initialize domain by importing python class and calling __init__ without arguments
             # using the module and class specified in the ros parameters
-            self._domain = getattr(__import__(domain_module, fromlist=[domain_class]), domain_class)(demo_items)
+            self._domain = getattr(__import__(domain_module, fromlist=[domain_class]), domain_class)(
+                list(self.initial_item_locations.keys())
+            )
         except ImportError as e:
             print(f"Could not import {domain_module} module for {domain_class} domain: {e}")
 
@@ -76,20 +85,12 @@ class TaskServerNode:
     def set_item_locations(self) -> None:
         # TODO OLD still using items and locations from castle demo
         # HACK hardcoded initial object locations
-        initial_item_locations = {}
-        initial_item_locations[Item.get("multimeter_1")] = Location.get("table_3")
-        initial_item_locations[Item.get("relay_1")] = Location.get("table_3")
-        initial_item_locations[Item.get("screwdriver_1")] = Location.get("table_3")
-        initial_item_locations[Item.get("power_drill_with_grip_1")] = Location.get("table_2")
-        initial_item_locations[Item.get("hot_glue_gun_1")] = Location.get("table_2")
-        initial_item_locations[Item.get("klt_1")] = Location.get("table_2")
-        initial_item_locations[Item.get("klt_2")] = Location.get("table_1")
-        initial_item_locations[Item.get("klt_3")] = Location.get("table_3")
         # add only items, which are not already set to avoid overriding perceived locations
-        for item in list(initial_item_locations.keys()):
-            if item in self._domain.env.believed_item_locations:
-                del initial_item_locations[item]
-        self._domain.env.believed_item_locations.update(initial_item_locations)
+        item_loc = {}
+        for item, loc in self.initial_item_locations.items():
+            if item not in self._domain.env.believed_item_locations:
+                item_loc[item] = loc
+        self._domain.env.believed_item_locations.update(item_loc)
 
     def generate_and_execute_plan(self, request: PlanAndExecuteTasksGoal) -> None:
         retries_before_abortion = 3

--- a/tables_demo_planning/nodes/task_server_node.py
+++ b/tables_demo_planning/nodes/task_server_node.py
@@ -1,16 +1,17 @@
 #!/usr/bin/env python3
 
 import rospy
-import unified_planning
 import actionlib
 from collections import defaultdict
-from typing import Dict
+from typing import Dict, List
 from up_esb.plexmo import PlanDispatcher
 from tables_demo_planning.msg import (
     PlanAndExecuteTaskAction,
     PlanAndExecuteTaskGoal,
     PlanAndExecuteTaskResult,
 )
+from unified_planning.shortcuts import get_environment
+from tables_demo_planning.components import Item, Location
 
 
 class TaskServerNode:
@@ -21,13 +22,24 @@ class TaskServerNode:
             default="/mobipick/task_planning",
         )
 
+        demo_items = [
+            Item.get("multimeter_1"),
+            Item.get("relay_1"),
+            Item.get("screwdriver_1"),
+            Item.get("power_drill_with_grip_1"),
+            Item.get("hot_glue_gun_1"),
+            Item.get("klt_1"),
+            Item.get("klt_2"),
+            Item.get("klt_3"),
+        ]
+
         domain_class = rospy.get_param("~domain_class", default="HierarchicalDomain")
         domain_module = rospy.get_param("~domain_module", default="tables_demo_planning.hierarchical_domain")
 
         try:
             # Initialize domain by importing python class and calling __init__ without arguments
             # using the module and class specified in the ros parameters
-            self._domain = getattr(__import__(domain_module, fromlist=[domain_class]), domain_class)()
+            self._domain = getattr(__import__(domain_module, fromlist=[domain_class]), domain_class)(demo_items)
         except ImportError as e:
             print(f"Could not import {domain_module} module for {domain_class} domain: {e}")
 
@@ -44,21 +56,6 @@ class TaskServerNode:
 
     def preempt_cb(self) -> None:
         self._domain.problem.clear_goals()
-
-    def solve_problem(self, problem: Problem) -> Plan:
-        # TODO Remove or adapt for new domain
-        """Solve planning problem and return plan."""
-        result = OneshotPlanner(
-            problem_kind=problem.kind,
-            optimality_guarantee=OptimalityGuarantee.SOLVED_OPTIMALLY,
-        ).solve(problem)
-        if result.status and result.status.value > 2:
-            if result.log_messages:
-                rospy.logerr(f"Error during plan generation: {result.log_messages[0].message}")
-            else:
-                rospy.logerr(f"Error during plan generation: {result.status}")
-        rospy.loginfo(f"Result received from '{result.engine_name}' planner.")
-        return result.plan if result.plan else None
 
     def set_goals(self, task: str, parameters: List[str]) -> None:
         """Set the goals given by the task message."""
@@ -79,27 +76,24 @@ class TaskServerNode:
         # TODO OLD still using items and locations from castle demo
         # HACK hardcoded initial object locations
         initial_item_locations = {}
-        initial_item_locations[Item.multimeter] = Location.table_3
-        initial_item_locations[Item.relay] = Location.table_3
-        initial_item_locations[Item.screwdriver] = Location.table_3
-        initial_item_locations[Item.box] = Location.table_2
-        initial_item_locations[Item.power_drill] = Location.table_2
+        initial_item_locations[Item.get("multimeter_1")] = Location.get("table_3")
+        initial_item_locations[Item.get("relay_1")] = Location.get("table_3")
+        initial_item_locations[Item.get("screwdriver_1")] = Location.get("table_3")
+        initial_item_locations[Item.get("power_drill_with_grip_1")] = Location.get("table_2")
+        initial_item_locations[Item.get("hot_glue_gun_1")] = Location.get("table_2")
+        initial_item_locations[Item.get("klt_1")] = Location.get("table_2")
+        initial_item_locations[Item.get("klt_2")] = Location.get("table_1")
+        initial_item_locations[Item.get("klt_3")] = Location.get("table_3")
         # add only items, which are not already set to avoid overriding perceived locations
         for item in list(initial_item_locations.keys()):
             if item in self._domain.env.believed_item_locations:
                 del initial_item_locations[item]
         self._domain.env.believed_item_locations.update(initial_item_locations)
 
-    def generate_plan(self, request) -> Plan:
-        # TODO Remove or change to new domain
-        # generate problem and plan
-        self._domain.set_initial_values(self._domain.problem)
-        self.set_goals(request.task, request.parameters)
-        return self.solve_problem(self._domain.problem)
-
     def generate_and_execute_plan(self, request: PlanAndExecuteTaskGoal) -> None:
         retries_before_abortion = 3
         error_counts: Dict[str, int] = defaultdict(int)
+        self.set_item_locations()
         plan = self._domain.create_plan(request.task, request.parameters)
 
         if not plan:
@@ -122,7 +116,7 @@ class TaskServerNode:
                     plan = self._domain.create_plan(request.task, request.parameters)
                     actions = plan.action_plan.actions
                     break
-                executable_action, parameters = self._domain.get_executable_action(action)
+                executable_action, parameters = self._domain.domain.get_executable_action(action)
                 print(action)
 
                 # Execute action.
@@ -134,7 +128,7 @@ class TaskServerNode:
                     return
                 if result is not None:
                     if not result:
-                        error_counts[self._domain.label(action)] += 1
+                        error_counts[self._domain.tables_demo_api.label(action)] += 1
                         # Note: This will also fail if two different failures occur successively.
                         if retries_before_abortion <= 0 or any(count >= 3 for count in error_counts.values()):
                             print("Task could not be completed even after retrying.")
@@ -163,7 +157,7 @@ class TaskServerNode:
 
 
 if __name__ == "__main__":
-    unified_planning.shortcuts.get_environment().credits_stream = None
+    get_environment().credits_stream = None
     try:
         TaskServerNode()
         rospy.spin()

--- a/tables_demo_planning/nodes/uplexmo_tables_demo_node.py
+++ b/tables_demo_planning/nodes/uplexmo_tables_demo_node.py
@@ -44,8 +44,8 @@ Development in progress.
 import sys
 import rospy
 import unified_planning
-from typing import Optional, Set, Dict
-from tables_demo_planning.components import Item, Location
+from typing import Optional, Set
+from tables_demo_planning.components import Location
 from tables_demo_planning.tables_demo_api import TablesDemoAPI
 from tables_demo_planning.subplan_visualization import SubPlanVisualization
 from unified_planning.plans import ActionInstance
@@ -54,8 +54,8 @@ from unified_planning.model import UPState
 
 
 class TablesDemoOrchestrator:
-    def __init__(self, item_locations: Dict[Item, Location]) -> None:
-        self._demo_api = TablesDemoAPI(item_locations)
+    def __init__(self) -> None:
+        self._demo_api = TablesDemoAPI()
         self.visualization = SubPlanVisualization()
         self.espeak_pub: Optional[rospy.Publisher] = None
         self._trigger_replanning = False  # Temporary solution until it is provided by dispatcher
@@ -182,7 +182,7 @@ class TablesDemoOrchestrator:
                 "Scenario: Mobipick shall bring the box with the multimeter"
                 f" inside to {self._demo_api.domain.objects[target_location.name]}."
             )
-            self._demo_api.domain.set_goals(self._demo_api.problem, list(item_locations.keys()), target_location)
+            self._demo_api.domain.set_goals(self._demo_api.problem, self._demo_api.demo_items, target_location)
 
         self._executed_actions: Set[str] = set()
 
@@ -214,18 +214,10 @@ class TablesDemoOrchestrator:
 if __name__ == '__main__':
     unified_planning.shortcuts.get_environment().credits_stream = None
 
-    # Define environment values.
-    item_locations = {
-        Item.get("multimeter_1"): Location.get("table_3"),
-        Item.get("klt_1"): Location.get("table_2"),
-        Item.get("klt_2"): Location.get("table_1"),
-        Item.get("klt_3"): Location.get("table_3"),
-    }
-
     try:
         # Define goal.
         goal_strs = sys.argv[1:]
-        tdo = TablesDemoOrchestrator(item_locations)
+        tdo = TablesDemoOrchestrator()
 
         if goal_strs:
             tdo.generate_and_execute_plan(goal_strs)

--- a/tables_demo_planning/package.xml
+++ b/tables_demo_planning/package.xml
@@ -13,6 +13,11 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>message_generation</build_depend>
+  <build_depend>actionlib_msgs</build_depend>
+  <build_export_depend>actionlib_msgs</build_export_depend>
+
+  <exec_depend>message_runtime</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>python3-rospkg</exec_depend>
   <exec_depend>python3-yaml</exec_depend>

--- a/tables_demo_planning/src/tables_demo_planning/domain.py
+++ b/tables_demo_planning/src/tables_demo_planning/domain.py
@@ -249,7 +249,7 @@ class Domain(Bridge):
         store_item.add_effect(self.robot_has(robot, item1), False)
         store_item.add_effect(self.robot_has(robot, self.get(Item, "nothing")), True)
         for arm_pose in self.get_objects_for_type(ArmPose).values():
-            store_item.add_effect(self.robot_arm_at(robot, arm_pose), arm_pose == self.get(ArmPose, "arm_pose_home"))
+            store_item.add_effect(self.robot_arm_at(robot, arm_pose), arm_pose == self.get(ArmPose, "home"))
         store_item.add_effect(self.believe_item_at(item1, self.get(Location, "on_robot")), False)
         store_item.add_effect(self.believe_item_at(item1, self.get(Location, "in_klt")), True)
         store_item.add_effect(self.believe_item_in(item1, item2), True)

--- a/tables_demo_planning/src/tables_demo_planning/hierarchical_domain.py
+++ b/tables_demo_planning/src/tables_demo_planning/hierarchical_domain.py
@@ -899,7 +899,11 @@ class HierarchicalDomain:
                         print("Picking up KLT OBSOLETE.")
                         self.visualization.cancel(action_name)
                         print("Replanning")
-                        actions = self.replan()
+                        plan = self.replan()
+                        if plan is None:
+                            print("Execution ended because no plan could be found.")
+                            return
+                        actions = plan.action_plan.actions
                         break
 
                 self.visualization.execute(action_name)
@@ -919,7 +923,11 @@ class HierarchicalDomain:
                         if self.env.believed_item_locations[self.env.item_search] != Location.get("anywhere"):
                             print(f"Search for {self.env.item_search.name} OBSOLETE.")
                             self.visualization.cancel(action_name)
-                            actions = self.replan()
+                            plan = self.replan()
+                            if plan is None:
+                                print("Execution ended because no plan could be found.")
+                                return
+                            actions = plan.action_plan.actions
                             break
 
                         # Search for item by creating and executing a subplan.
@@ -929,8 +937,9 @@ class HierarchicalDomain:
                             self.subproblem,
                             self.search_item(self.domain.robot, self.domain.objects[self.env.item_search.name]),
                         )
-                        subactions = self.solve_problem(self.subproblem)
-                        assert subactions, f"No solution for: {self.subproblem}"
+                        subplan = self.solve_problem(self.subproblem)
+                        assert subplan, f"No solution for: {self.subproblem}"
+                        subactions = subplan.action_plan.actions
                         print("- Search plan:")
                         print('\n'.join(map(str, subactions)))
                         self.visualization.set_actions(
@@ -1006,12 +1015,20 @@ class HierarchicalDomain:
                             return
 
                         retries_before_abortion -= 1
-                        actions = self.replan()
+                        plan = self.replan()
+                        if plan is None:
+                            print("Execution ended because no plan could be found.")
+                            return
+                        actions = plan.action_plan.actions
                         break
                 else:
                     self.visualization.cancel(action_name)
                     retries_before_abortion = self.tables_demo_api.RETRIES_BEFORE_ABORTION
-                    actions = self.replan()
+                    plan = self.replan()
+                    if plan is None:
+                        print("Execution ended because no plan could be found.")
+                        return
+                    actions = plan.action_plan.actions
                     break
             else:
                 break

--- a/tables_demo_planning/src/tables_demo_planning/hierarchical_domain.py
+++ b/tables_demo_planning/src/tables_demo_planning/hierarchical_domain.py
@@ -828,14 +828,19 @@ class HierarchicalDomain:
         problem.task_network._subtasks.clear()
 
     def create_task_from_string(self, task_name: str, parameters: List[str]) -> Optional[Task]:
-        param_objs = [self.domain.objects[param] for param in parameters]
-        if self.problem.has_task(task_name):
-            task = self.problem.get_task(task_name)
-        elif self.problem.has_action(task_name):
-            return Subtask(self.problem.action(task_name), *param_objs)
-        else:
-            return None
-        return task(*param_objs)
+        try:
+            parameterized_task = None
+            param_objs = [self.domain.objects[param] for param in parameters]
+            if self.problem.has_task(task_name):
+                parameterized_task = self.problem.get_task(task_name)(*param_objs)
+            elif self.problem.has_action(task_name):
+                parameterized_task = Subtask(self.problem.action(task_name), *param_objs)
+        except ValueError as e:
+            rospy.logerr(f"Task {task_name}: {e}")
+        except KeyError as e:
+            rospy.logerr(f"Parameter {e} does not exist in planning domain!")
+
+        return parameterized_task
 
     def create_plan(self, task_name: str, parameters: List[str]):
         """Create a plan that can be used in the task server"""

--- a/tables_demo_planning/src/tables_demo_planning/hierarchical_domain.py
+++ b/tables_demo_planning/src/tables_demo_planning/hierarchical_domain.py
@@ -50,8 +50,8 @@ from tables_demo_planning.tables_demo_api import TablesDemoAPI
 
 
 class HierarchicalDomain:
-    def __init__(self, api_items: Iterable[Item]) -> None:
-        self.tables_demo_api = TablesDemoAPI(api_items)
+    def __init__(self) -> None:
+        self.tables_demo_api = TablesDemoAPI()
         # Aliases for domain, env and visualization variable
         self.domain = self.tables_demo_api.domain
         self.env = self.tables_demo_api.env

--- a/tables_demo_planning/src/tables_demo_planning/hierarchical_domain.py
+++ b/tables_demo_planning/src/tables_demo_planning/hierarchical_domain.py
@@ -42,7 +42,7 @@ from geometry_msgs.msg import Pose
 from unified_planning.model import Fluent, InstantaneousAction, Object, Action, Problem
 from unified_planning.model.htn import HierarchicalProblem, Method, Task, Subtask
 from unified_planning.shortcuts import Equals, Not, Or, OneshotPlanner
-from unified_planning.plans import PlanKind, ActionInstance
+from unified_planning.plans import PlanKind, HierarchicalPlan
 from unified_planning.model.metrics import MinimizeSequentialPlanLength
 from unified_planning.engines import OptimalityGuarantee
 from tables_demo_planning.components import Robot, ArmPose, Item, Location
@@ -792,7 +792,7 @@ class HierarchicalDomain:
 
         return problem
 
-    def solve_problem(self, problem: Problem) -> Optional[List[ActionInstance]]:
+    def solve_problem(self, problem: Problem) -> Optional[HierarchicalPlan]:
         """Solve planning problem and return plan."""
         result = OneshotPlanner(
             name="aries", problem_kind=problem.kind, optimality_guarantee=OptimalityGuarantee.SOLVED_OPTIMALLY
@@ -807,17 +807,14 @@ class HierarchicalDomain:
         if result.plan is not None:
             plan = result.plan
             if plan.kind == PlanKind.HIERARCHICAL_PLAN:
-                # First check if contained action plan is time-triggered plan
-                # (if aries returns an empty plan it is a time-triggered, which
-                # cant be converted to sequential and produces an error)
+                # Check if contained action plan is of type time-triggered plan
+                # (if aries returns an empty plan it is a time-triggered plan)
                 if plan.action_plan and plan.action_plan.kind == PlanKind.TIME_TRIGGERED_PLAN:
                     return None
-                # Convert hierarchical plan to sequential plan for execution
-                plan = plan.convert_to(PlanKind.SEQUENTIAL_PLAN, self.problem)
-            return plan.actions if plan.actions else None
+            return plan
         return None
 
-    def replan(self) -> Optional[List[ActionInstance]]:
+    def replan(self) -> Optional[HierarchicalPlan]:
         """Print believed item locations, initialize UP problem, and solve it."""
         self.env.print_believed_item_locations()
         self.domain.set_initial_values(self.problem)
@@ -829,6 +826,26 @@ class HierarchicalDomain:
 
     def clear_tasks(self, problem: HierarchicalProblem) -> None:
         problem.task_network._subtasks.clear()
+
+    def create_task_from_string(self, task_name: str, parameters: List[str]) -> Optional[Task]:
+        param_objs = [self.domain.objects[param] for param in parameters]
+        if self.problem.has_task(task_name):
+            task = self.problem.get_task(task_name)
+        elif self.problem.has_action(task_name):
+            return Subtask(self.problem.action(task_name), *param_objs)
+        else:
+            return None
+        return task(*param_objs)
+
+    def create_plan(self, task_name: str, parameters: List[str]):
+        """Create a plan that can be used in the task server"""
+        self.clear_tasks(self.problem)
+        task = self.create_task_from_string(task_name, parameters)
+        if task:
+            self.set_task(self.problem, task)
+        else:
+            return None
+        return self.replan()
 
     def run(self, target_item: Item, target_klt: Item, target_location: Location) -> None:
         """Run the mobipick tables demo."""
@@ -846,10 +863,12 @@ class HierarchicalDomain:
                 self.domain.objects[target_location.name],
             ),
         )
-        actions = self.replan()
-        if actions is None:
+        plan = self.replan()
+        if plan is None:
             print("Execution ended because no plan could be found.")
             return
+
+        actions = plan.action_plan.actions
 
         # Loop action execution as long as there are actions.
         while actions:

--- a/tables_demo_planning/src/tables_demo_planning/tables_demo_api.py
+++ b/tables_demo_planning/src/tables_demo_planning/tables_demo_api.py
@@ -1,7 +1,7 @@
 import rospy
 import rosparam
 
-from typing import Dict, Iterable, List, Set, Sequence, Union, Optional, Callable
+from typing import Dict, List, Set, Sequence, Union, Optional, Callable
 from collections import defaultdict
 from geometry_msgs.msg import Pose, Point
 from std_msgs.msg import String
@@ -20,7 +20,7 @@ from tables_demo_planning.subplan_visualization import SubPlanVisualization
 class TablesDemoAPI:
     RETRIES_BEFORE_ABORTION = 2
 
-    def __init__(self, api_items: Iterable[Item]) -> None:
+    def __init__(self) -> None:
         self.mobipick = Robot("mobipick")
         self.mobipick_api = mobipick_api_robot("mobipick", True, True)
         self.domain = TablesDemoDomain(self.mobipick)
@@ -28,16 +28,23 @@ class TablesDemoAPI:
         rosparam_namespace = "/mobipick/tables_demo_planning"
         self.api_poses: Dict[str, Pose] = {}
         table_names: List[str] = []
+        self.initial_item_locations: Dict[Item, Location] = {}
         for param_path in rosparam.list_params(rosparam_namespace):
             assert isinstance(param_path, str)
             param = rosparam.get_param(param_path)
-            param_name = param_path.rsplit('/', maxsplit=1)[-1]
-            # Collect poses from rosparams.
-            if is_instance(param, Sequence[Sequence[Union[float, int]]]) and tuple(map(len, param)) == (3, 4):
-                self.api_poses[param_name] = TuplePose.to_pose(param)
-            # Collect table names from rosparam names.
-            if param_name.startswith("base_table_") and param_name.endswith("_pose"):
-                table_names.append(param_name[5:-5])
+            split_param_path = param_path.rsplit('/', maxsplit=2)
+            param_name = split_param_path[-1]
+            param_file = split_param_path[-2]
+            if "initial_item_locations" in param_file:
+                # Collect items used in the demo from rosparams
+                self.initial_item_locations[Item.get(param_name)] = Location.get(param)
+            elif "poses" in param_file:
+                # Collect poses from rosparams.
+                if is_instance(param, Sequence[Sequence[Union[float, int]]]) and tuple(map(len, param)) == (3, 4):
+                    self.api_poses[param_name] = TuplePose.to_pose(param)
+                # Collect table names from rosparam names.
+                if param_name.startswith("base_table_") and param_name.endswith("_pose"):
+                    table_names.append(param_name[5:-5])
         if len({TuplePose.from_pose(pose) for pose in self.api_poses.values()}) < len(self.api_poses):
             rospy.logwarn(
                 f"Duplicate poses in rosparam namespace '{rosparam_namespace}'"
@@ -49,16 +56,16 @@ class TablesDemoAPI:
         self.api_poses["klt_search_pose"] = Pose(position=Point(x=-5.0))
         self.api_pose_names = {id(pose): name for name, pose in self.api_poses.items()}
         self.poses = self.domain.create_objects(self.api_poses)
-        self.items = self.domain.create_objects({item.name: item for item in api_items})
+        self.items = self.domain.create_objects({item.name: item for item in self.initial_item_locations.keys()})
         self.tables = [self.domain.get(Location, name) for name in table_names]
         self.arm_poses = [
             self.domain.get(ArmPose, arm_pose)
             for arm_pose in ["unknown", "home", "transport", "handover", "observe100cm_right"]
         ]
-        self.env = EnvironmentRepresentation(api_items)
+        self.env = EnvironmentRepresentation(list(self.initial_item_locations.keys()))
         self.env.perceive = lambda _, location: self.perceive(_, location)
         self.env.initialize_robot_states(self.domain.api_robot, self.api_poses["base_home_pose"])
-        self.demo_items = list(api_items)
+        self.demo_items = list(self.initial_item_locations.keys())
 
         self.domain.set_fluent_functions(
             [


### PR DESCRIPTION
A version of this task server was already present in the ai-demo-day branch. The commits here are based on that and updated to the changes done in the refactored domain in this [pull request](https://github.com/DFKI-NI/mobipick_labs/pull/42).

Summary of changes:
- Adds a simple_action_server and corresponding ros actions to retrieve hierarchical tasks. When retrieving a task, the planning is triggered with the given task and the plan is executed.
- Adds a simple_action_client  to give tasks easily over the command line e.g.
`rosrun tables_demo_planning task_server_client.py move_item mobipick multimeter_1 table_2`

The action server receives all item locations as a [parameter](https://github.com/DFKI-NI/mobipick_labs/commit/57b5d1efdc5f58440870aee2e0f2a7c43708caf9) from the parameter server. This is needed so that tasks like move_item, which requires the knowledge of item positions, can be executed (item search is not part of the move_item task). Additionally this parameter is needed to create UP objects of what items are present in the environment, similar to the demo_items variable in the other demo nodes e.g. [demo_items](https://github.com/DFKI-NI/mobipick_labs/blob/noetic/tables_demo_planning/nodes/hierarchical_demo_node.py#L85-L90). The locations can also be set to be "unknown" and then the search task can be given as a separate task before other tasks as well.

