### PR TITLE
Enable additional YCB objects to be grasped

### DIFF
--- a/tables_demo_bringup/launch/bringup.launch
+++ b/tables_demo_bringup/launch/bringup.launch
@@ -2,7 +2,7 @@
 <launch>
   <arg name="simulation" default="false" />
   <arg name="world_config" default="moelk_tables" doc="objects arrangement, options: moelk_tables, cic_tables, truck_assembly" />
-  <arg name="objects_of_interest" default="[relay, screwdriver, multimeter, power_drill_with_grip, hot_glue_gun, klt]"/>
+  <arg name="objects_of_interest" default="[relay, screwdriver, multimeter, power_drill_with_grip, hot_glue_gun, klt, bleach, mustard, soup, meat]"/>
   <arg name="dope_converter_config" default="$(find pbr_objects)/config/class_ids.yaml" />
 
   <!-- please run separately! : -->

--- a/tables_demo_bringup/launch/includes/grasp_planning.launch
+++ b/tables_demo_bringup/launch/includes/grasp_planning.launch
@@ -46,6 +46,14 @@
               command="load" ns="handcoded_grasp_planner_transforms" />
     <rosparam file="$(find mobipick_pick_n_place)/config/grasplan/object_grasps/handcoded_grasp_planner_hot_glue_gun.yaml"
               command="load" ns="handcoded_grasp_planner_transforms" />
+    <rosparam file="$(find mobipick_pick_n_place)/config/grasplan/object_grasps/handcoded_grasp_planner_soup.yaml"
+              command="load" ns="handcoded_grasp_planner_transforms" />
+    <rosparam file="$(find mobipick_pick_n_place)/config/grasplan/object_grasps/handcoded_grasp_planner_bleach.yaml"
+              command="load" ns="handcoded_grasp_planner_transforms" />
+    <rosparam file="$(find mobipick_pick_n_place)/config/grasplan/object_grasps/handcoded_grasp_planner_mustard.yaml"
+              command="load" ns="handcoded_grasp_planner_transforms" />
+    <rosparam file="$(find mobipick_pick_n_place)/config/grasplan/object_grasps/handcoded_grasp_planner_meat.yaml"
+              command="load" ns="handcoded_grasp_planner_transforms" />
   </node>
 
 </launch>


### PR DESCRIPTION
Since https://git.ni.dfki.de/mobipick/mobipick/-/merge_requests/22 is now merged, we can also merge this change, correct? I've found it (uncommitted) on the Mobipick robot.